### PR TITLE
[SECD] Bump OpenTitan for reduced memory and iDMA.

### DIFF
--- a/Bender.lock
+++ b/Bender.lock
@@ -338,7 +338,7 @@ packages:
     - common_cells
     - common_verification
   opentitan:
-    revision: c3d6967775e80c5a2cb8086e2618d1a829464bc5
+    revision: 3fc11c14f29a161054766fabd95f90ab2a9e473a
     version: null
     source:
       Git: https://github.com/pulp-platform/opentitan.git

--- a/Bender.lock
+++ b/Bender.lock
@@ -344,6 +344,9 @@ packages:
       Git: https://github.com/pulp-platform/opentitan.git
     dependencies:
     - axi
+    - cluster_interconnect
+    - idma
+    - register_interface
   opentitan_peripherals:
     revision: cd3153de2783abd3d03d0595e6c4b32413c62f14
     version: 0.4.0

--- a/Bender.lock
+++ b/Bender.lock
@@ -338,7 +338,7 @@ packages:
     - common_cells
     - common_verification
   opentitan:
-    revision: 6a9fd5544933f9aea3469f4d1ed612844aab1982
+    revision: c3d6967775e80c5a2cb8086e2618d1a829464bc5
     version: null
     source:
       Git: https://github.com/pulp-platform/opentitan.git

--- a/Bender.lock
+++ b/Bender.lock
@@ -338,7 +338,7 @@ packages:
     - common_cells
     - common_verification
   opentitan:
-    revision: 74e7d6ca17e6a46e727ae2ae11177611232eaeb9
+    revision: 6a9fd5544933f9aea3469f4d1ed612844aab1982
     version: null
     source:
       Git: https://github.com/pulp-platform/opentitan.git

--- a/Bender.yml
+++ b/Bender.yml
@@ -18,7 +18,7 @@ dependencies:
   dyn_mem:            { git: https://github.com/pulp-platform/dyn_spm.git,              rev: 480590062742230dc9bd4050358a15b4747bdf34 } # branch: main
   safety_island:      { git: https://github.com/pulp-platform/safety_island.git,        rev: aaef55c798ab53560faaf451a86668fa1e6d0f3b } # branch: carfield
   pulp_cluster:       { git: https://github.com/pulp-platform/pulp_cluster.git,         rev: 3cd3e83fdd7a791e8ae54aef39423004581c8a48 } # branch: astral
-  opentitan:          { git: https://github.com/pulp-platform/opentitan.git,            rev: 6a9fd5544933f9aea3469f4d1ed612844aab1982 } # branch: mc/astral
+  opentitan:          { git: https://github.com/pulp-platform/opentitan.git,            rev: c3d6967775e80c5a2cb8086e2618d1a829464bc5 } # branch: mc/astral
   mailbox_unit:       { git: https://github.com/pulp-platform/mailbox_unit.git,         version: 1.1.0                                }
   apb:                { git: https://github.com/pulp-platform/apb.git,                  version: 0.2.3                                }
   timer_unit:         { git: https://github.com/pulp-platform/timer_unit.git,           version: 1.0.2                                }

--- a/Bender.yml
+++ b/Bender.yml
@@ -18,7 +18,7 @@ dependencies:
   dyn_mem:            { git: https://github.com/pulp-platform/dyn_spm.git,              rev: 480590062742230dc9bd4050358a15b4747bdf34 } # branch: main
   safety_island:      { git: https://github.com/pulp-platform/safety_island.git,        rev: aaef55c798ab53560faaf451a86668fa1e6d0f3b } # branch: carfield
   pulp_cluster:       { git: https://github.com/pulp-platform/pulp_cluster.git,         rev: 3cd3e83fdd7a791e8ae54aef39423004581c8a48 } # branch: astral
-  opentitan:          { git: https://github.com/pulp-platform/opentitan.git,            rev: c3d6967775e80c5a2cb8086e2618d1a829464bc5 } # branch: mc/astral
+  opentitan:          { git: https://github.com/pulp-platform/opentitan.git,            rev: 3fc11c14f29a161054766fabd95f90ab2a9e473a } # branch: mc/astral
   mailbox_unit:       { git: https://github.com/pulp-platform/mailbox_unit.git,         version: 1.1.0                                }
   apb:                { git: https://github.com/pulp-platform/apb.git,                  version: 0.2.3                                }
   timer_unit:         { git: https://github.com/pulp-platform/timer_unit.git,           version: 1.0.2                                }

--- a/Bender.yml
+++ b/Bender.yml
@@ -17,8 +17,8 @@ dependencies:
   hyperbus:           { git: https://github.com/pulp-platform/hyperbus.git,             rev: f039e601c8b6590181734e6d26ff8b77aa380412 } # branch: chi/add_fsm_with_Tcsh
   dyn_mem:            { git: https://github.com/pulp-platform/dyn_spm.git,              rev: 480590062742230dc9bd4050358a15b4747bdf34 } # branch: main
   safety_island:      { git: https://github.com/pulp-platform/safety_island.git,        rev: aaef55c798ab53560faaf451a86668fa1e6d0f3b } # branch: carfield
-  pulp_cluster:       { git: https://github.com/pulp-platform/pulp_cluster.git,         rev: 3cd3e83fdd7a791e8ae54aef39423004581c8a48 } # branch: idw-conv
-  opentitan:          { git: https://github.com/pulp-platform/opentitan.git,            rev: 74e7d6ca17e6a46e727ae2ae11177611232eaeb9 } # branch: carfield_soc
+  pulp_cluster:       { git: https://github.com/pulp-platform/pulp_cluster.git,         rev: 3cd3e83fdd7a791e8ae54aef39423004581c8a48 } # branch: astral
+  opentitan:          { git: https://github.com/pulp-platform/opentitan.git,            rev: 6a9fd5544933f9aea3469f4d1ed612844aab1982 } # branch: mc/astral
   mailbox_unit:       { git: https://github.com/pulp-platform/mailbox_unit.git,         version: 1.1.0                                }
   apb:                { git: https://github.com/pulp-platform/apb.git,                  version: 0.2.3                                }
   timer_unit:         { git: https://github.com/pulp-platform/timer_unit.git,           version: 1.0.2                                }

--- a/carfield.mk
+++ b/carfield.mk
@@ -23,6 +23,7 @@ CAR_SW_DIR  := $(CAR_ROOT)/sw
 CAR_TGT_DIR := $(CAR_ROOT)/target/
 CAR_XIL_DIR := $(CAR_TGT_DIR)/xilinx
 CAR_SIM_DIR := $(CAR_TGT_DIR)/sim
+SECD_ROOT    ?= $(shell $(BENDER) path opentitan)
 # Questasim
 CAR_VSIM_DIR := $(CAR_TGT_DIR)/sim/vsim
 
@@ -213,7 +214,11 @@ pulpd-sw-build: pulpd-sw-init
 ## Initialize Carfield HW. This step takes care of the generation of the missing hardware or the
 ## update of default HW configurations in some of the domains. See the two prerequisite's comment
 ## for more information.
-car-hw-init: spatzd-hw-init chs-hw-init
+car-hw-init: spatzd-hw-init chs-hw-init secd-hw-init
+
+#Build OpenTitan's debug rom with support for coreid=0x4
+secd-hw-init:
+	$(MAKE) -C $(SECD_ROOT)/hw/vendor/pulp_riscv_dbg/debug_rom clean all FLAGS=-DCARFIELD=1
 
 ## @section Carfield platform PCRs generation
 .PHONY: regenerate_soc_regs

--- a/carfield.mk
+++ b/carfield.mk
@@ -47,7 +47,7 @@ include $(CAR_ROOT)/bender-safed.mk
 ######################
 
 CAR_NONFREE_REMOTE ?= git@iis-git.ee.ethz.ch:astral/astral-nonfree.git
-CAR_NONFREE_COMMIT ?= 711d0097
+CAR_NONFREE_COMMIT ?= 3b5694e683d1f937719652f61ab2b433ad6dc5d0
 
 ## @section Carfield platform nonfree components
 ## Clone the non-free verification IP for Carfield. Some components such as CI scripts and ASIC

--- a/carfield.mk
+++ b/carfield.mk
@@ -47,7 +47,7 @@ include $(CAR_ROOT)/bender-safed.mk
 ######################
 
 CAR_NONFREE_REMOTE ?= git@iis-git.ee.ethz.ch:astral/astral-nonfree.git
-CAR_NONFREE_COMMIT ?= 3b5694e683d1f937719652f61ab2b433ad6dc5d0
+CAR_NONFREE_COMMIT ?= dcb1a4bcb62b087dab1f46bfff265cba324ae23b
 
 ## @section Carfield platform nonfree components
 ## Clone the non-free verification IP for Carfield. Some components such as CI scripts and ASIC

--- a/carfield.mk
+++ b/carfield.mk
@@ -23,7 +23,7 @@ CAR_SW_DIR  := $(CAR_ROOT)/sw
 CAR_TGT_DIR := $(CAR_ROOT)/target/
 CAR_XIL_DIR := $(CAR_TGT_DIR)/xilinx
 CAR_SIM_DIR := $(CAR_TGT_DIR)/sim
-SECD_ROOT    ?= $(shell $(BENDER) path opentitan)
+SECD_ROOT ?= $(shell $(BENDER) path opentitan)
 # Questasim
 CAR_VSIM_DIR := $(CAR_TGT_DIR)/sim/vsim
 
@@ -216,7 +216,7 @@ pulpd-sw-build: pulpd-sw-init
 ## for more information.
 car-hw-init: spatzd-hw-init chs-hw-init secd-hw-init
 
-#Build OpenTitan's debug rom with support for coreid=0x4
+#Build OpenTitan's debug rom with support for coreid != 0x0
 secd-hw-init:
 	$(MAKE) -C $(SECD_ROOT)/hw/vendor/pulp_riscv_dbg/debug_rom clean all FLAGS=-DCARFIELD=1
 

--- a/hw/carfield.sv
+++ b/hw/carfield.sv
@@ -428,7 +428,6 @@ logic [    LogDepth:0] llc_w_rptr;
 
 logic hyper_isolate_req, hyper_isolated_rsp;
 logic security_island_isolate_req;
-logic unused;
 
 logic [iomsb(Cfg.AxiExtNumSlv):0] slave_isolate_req, slave_isolated_rsp, slave_isolated;
 logic [iomsb(Cfg.AxiExtNumMst):0] master_isolated_rsp;
@@ -1682,7 +1681,7 @@ if (CarfieldIslandsCfg.secured.enable) begin : gen_secure_subsystem
                    narrow_axi_data_t, narrow_axi_strb_t, narrow_axi_user_t)
 
   `ifndef SECD_NETLIST
-  secure_subsystem_synth_wrap_astral #(
+  security_island #(
     .HartIdOffs            ( OpnTitHartIdOffs                  ),
     .AxiAddrWidth          ( Cfg.AddrWidth                     ),
     .AxiDataWidth          ( Cfg.AxiDataWidth                  ),
@@ -1765,7 +1764,7 @@ if (CarfieldIslandsCfg.secured.enable) begin : gen_secure_subsystem
     .async_idma_axi_out_r_wptr_i  ( axi_mst_ext_r_wptr  [SecurityIslandiDMAMstIdx] ),
     .async_idma_axi_out_r_rptr_o  ( axi_mst_ext_r_rptr  [SecurityIslandiDMAMstIdx] ),
     .axi_isolate_i    ( security_island_isolate_req                                ),
-    .axi_isolated_o   ( { master_isolated_rsp[SecurityIslandiDMAMstIdx] master_isolated_rsp[SecurityIslandTlulMstIdx] } ),
+    .axi_isolated_o   ( { master_isolated_rsp[SecurityIslandiDMAMstIdx], master_isolated_rsp[SecurityIslandTlulMstIdx] } ),
      // Uart
     .ibex_uart_rx_i   ( uart_ot_rx_i  ),
     .ibex_uart_tx_o   ( uart_ot_tx_o  ),

--- a/hw/carfield.sv
+++ b/hw/carfield.sv
@@ -1678,7 +1678,8 @@ if (CarfieldIslandsCfg.secured.enable) begin : gen_secure_subsystem
   typedef logic [Cfg.AxiUserWidth-1:0]     narrow_axi_user_t;
   typedef logic [Cfg.AxiMstIdWidth-1:0]    narrow_axi_out_id_t;
 
-  `AXI_TYPEDEF_ALL(carfield_axi_mst_narrow, narrow_axi_addr_t, narrow_axi_out_id_t, narrow_axi_data_t, narrow_axi_strb_t, narrow_axi_user_t)
+  `AXI_TYPEDEF_ALL(carfield_axi_mst_narrow, narrow_axi_addr_t, narrow_axi_out_id_t, \
+                   narrow_axi_data_t, narrow_axi_strb_t, narrow_axi_user_t)
 
   `ifndef SECD_NETLIST
   secure_subsystem_synth_wrap_astral #(

--- a/hw/carfield.sv
+++ b/hw/carfield.sv
@@ -1668,7 +1668,7 @@ if (CarfieldIslandsCfg.secured.enable) begin : gen_secure_subsystem
   assign security_island_isolate_req  = car_regs_reg2hw.security_island_isolate.q &&
                                         !secure_boot_i;
   assign car_regs_hw2reg.security_island_isolate_status.d =
-         master_isolated_rsp[SecurityIslandTlulMstIdx] 
+         master_isolated_rsp[SecurityIslandTlulMstIdx]
          & master_isolated_rsp[SecurityIslandiDMAMstIdx];
   assign car_regs_hw2reg.security_island_isolate_status.de = 1'b1;
 

--- a/hw/carfield.sv
+++ b/hw/carfield.sv
@@ -1672,38 +1672,46 @@ if (CarfieldIslandsCfg.secured.enable) begin : gen_secure_subsystem
          master_isolated_rsp[SecurityIslandTlulMstIdx];
   assign car_regs_hw2reg.security_island_isolate_status.de = 1'b1;
 
+  typedef logic [Cfg.AddrWidth-1:0]        narrow_axi_addr_t;
+  typedef logic [AxiNarrowDataWidth-1:0]   narrow_axi_data_t;
+  typedef logic [AxiNarrowDataWidth/8-1:0] narrow_axi_strb_t;
+  typedef logic [Cfg.AxiUserWidth-1:0]     narrow_axi_user_t;
+  typedef logic [Cfg.AxiMstIdWidth-1:0]    narrow_axi_out_id_t;
+
+  `AXI_TYPEDEF_ALL(carfield_axi_mst_narrow, narrow_axi_addr_t, narrow_axi_out_id_t, narrow_axi_data_t, narrow_axi_strb_t, narrow_axi_user_t)
+
   `ifndef SECD_NETLIST
   secure_subsystem_synth_wrap_astral #(
-    .HartIdOffs            ( OpnTitHartIdOffs           ),
-    .AxiAddrWidth          ( Cfg.AddrWidth              ),
-    .AxiDataWidth          ( Cfg.AxiDataWidth           ),
-    .AxiUserWidth          ( Cfg.AxiUserWidth           ),
-    .AxiOutIdWidth         ( Cfg.AxiMstIdWidth          ),
-    .AxiOtAddrWidth        ( Cfg.AddrWidth              ),
-    .AxiOtDataWidth        ( AxiNarrowDataWidth         ), // TODO: why is this exposed?
-    .AxiOtUserWidth        ( Cfg.AxiUserWidth           ),
-    .AxiOtOutIdWidth       ( Cfg.AxiMstIdWidth          ),
-    .AsyncAxiOutAwWidth    ( CarfieldAxiMstAwWidth      ),
-    .AsyncAxiOutWWidth     ( CarfieldAxiMstWWidth       ),
-    .AsyncAxiOutBWidth     ( CarfieldAxiMstBWidth       ),
-    .AsyncAxiOutArWidth    ( CarfieldAxiMstArWidth      ),
-    .AsyncAxiOutRWidth     ( CarfieldAxiMstRWidth       ),
-    .axi_out_aw_chan_t     ( carfield_axi_mst_aw_chan_t ),
-    .axi_out_w_chan_t      ( carfield_axi_mst_w_chan_t  ),
-    .axi_out_b_chan_t      ( carfield_axi_mst_b_chan_t  ),
-    .axi_out_ar_chan_t     ( carfield_axi_mst_ar_chan_t ),
-    .axi_out_r_chan_t      ( carfield_axi_mst_r_chan_t  ),
-    .axi_out_req_t         ( carfield_axi_mst_req_t     ),
-    .axi_out_resp_t        ( carfield_axi_mst_rsp_t     ),
-    .axi_ot_out_aw_chan_t  ( carfield_axi_mst_aw_chan_t ),
-    .axi_ot_out_w_chan_t   ( carfield_axi_mst_w_chan_t  ),
-    .axi_ot_out_b_chan_t   ( carfield_axi_mst_b_chan_t  ),
-    .axi_ot_out_ar_chan_t  ( carfield_axi_mst_ar_chan_t ),
-    .axi_ot_out_r_chan_t   ( carfield_axi_mst_r_chan_t  ),
-    .axi_ot_out_req_t      ( carfield_axi_mst_req_t     ),
-    .axi_ot_out_resp_t     ( carfield_axi_mst_rsp_t     ),
-    .CdcSyncStages         ( SyncStages                 ),
-    .SyncStages            ( SyncStages                 )
+    .HartIdOffs            ( 4           ),
+    .AxiAddrWidth          ( Cfg.AddrWidth                     ),
+    .AxiDataWidth          ( Cfg.AxiDataWidth                  ),
+    .AxiUserWidth          ( Cfg.AxiUserWidth                  ),
+    .AxiOutIdWidth         ( Cfg.AxiMstIdWidth                 ),
+    .AxiOtAddrWidth        ( Cfg.AddrWidth                     ),
+    .AxiOtDataWidth        ( AxiNarrowDataWidth                ), // TODO: why is this exposed?
+    .AxiOtUserWidth        ( Cfg.AxiUserWidth                  ),
+    .AxiOtOutIdWidth       ( Cfg.AxiMstIdWidth                 ),
+    .AsyncAxiOutAwWidth    ( CarfieldAxiMstAwWidth             ),
+    .AsyncAxiOutWWidth     ( CarfieldAxiMstWWidth              ),
+    .AsyncAxiOutBWidth     ( CarfieldAxiMstBWidth              ),
+    .AsyncAxiOutArWidth    ( CarfieldAxiMstArWidth             ),
+    .AsyncAxiOutRWidth     ( CarfieldAxiMstRWidth              ),
+    .axi_out_aw_chan_t     ( carfield_axi_mst_aw_chan_t        ),
+    .axi_out_w_chan_t      ( carfield_axi_mst_w_chan_t         ),
+    .axi_out_b_chan_t      ( carfield_axi_mst_b_chan_t         ),
+    .axi_out_ar_chan_t     ( carfield_axi_mst_ar_chan_t        ),
+    .axi_out_r_chan_t      ( carfield_axi_mst_r_chan_t         ),
+    .axi_out_req_t         ( carfield_axi_mst_req_t            ),
+    .axi_out_resp_t        ( carfield_axi_mst_rsp_t            ),
+    .axi_ot_out_aw_chan_t  ( carfield_axi_mst_narrow_aw_chan_t ),
+    .axi_ot_out_w_chan_t   ( carfield_axi_mst_narrow_w_chan_t  ),
+    .axi_ot_out_b_chan_t   ( carfield_axi_mst_narrow_b_chan_t  ),
+    .axi_ot_out_ar_chan_t  ( carfield_axi_mst_narrow_ar_chan_t ),
+    .axi_ot_out_r_chan_t   ( carfield_axi_mst_narrow_r_chan_t  ),
+    .axi_ot_out_req_t      ( carfield_axi_mst_narrow_req_t     ),
+    .axi_ot_out_resp_t     ( carfield_axi_mst_narrow_resp_t    ),
+    .CdcSyncStages         ( SyncStages                        ),
+    .SyncStages            ( SyncStages                        )
   ) i_security_island (
   `else
   security_island i_security_island (

--- a/hw/carfield.sv
+++ b/hw/carfield.sv
@@ -1678,7 +1678,7 @@ if (CarfieldIslandsCfg.secured.enable) begin : gen_secure_subsystem
   typedef logic [Cfg.AxiUserWidth-1:0]     narrow_axi_user_t;
   typedef logic [Cfg.AxiMstIdWidth-1:0]    narrow_axi_out_id_t;
 
-  `AXI_TYPEDEF_ALL(carfield_axi_mst_narrow, narrow_axi_addr_t, narrow_axi_out_id_t, \
+  `AXI_TYPEDEF_ALL(carfield_axi_mst_narrow, narrow_axi_addr_t, narrow_axi_out_id_t,
                    narrow_axi_data_t, narrow_axi_strb_t, narrow_axi_user_t)
 
   `ifndef SECD_NETLIST

--- a/hw/carfield.sv
+++ b/hw/carfield.sv
@@ -1669,7 +1669,7 @@ if (CarfieldIslandsCfg.secured.enable) begin : gen_secure_subsystem
   assign security_island_isolate_req  = car_regs_reg2hw.security_island_isolate.q &&
                                         !secure_boot_i;
   assign car_regs_hw2reg.security_island_isolate_status.d =
-         master_isolated_rsp[SecurityIslandTlulMstIdx];
+         master_isolated_rsp[SecurityIslandTlulMstIdx] & master_isolated_rsp[SecurityIslandiDMAMstIdx];
   assign car_regs_hw2reg.security_island_isolate_status.de = 1'b1;
 
   typedef logic [Cfg.AddrWidth-1:0]        narrow_axi_addr_t;
@@ -1683,7 +1683,7 @@ if (CarfieldIslandsCfg.secured.enable) begin : gen_secure_subsystem
 
   `ifndef SECD_NETLIST
   secure_subsystem_synth_wrap_astral #(
-    .HartIdOffs            ( 4           ),
+    .HartIdOffs            ( OpnTitHartIdOffs                  ),
     .AxiAddrWidth          ( Cfg.AddrWidth                     ),
     .AxiDataWidth          ( Cfg.AxiDataWidth                  ),
     .AxiUserWidth          ( Cfg.AxiUserWidth                  ),
@@ -1764,8 +1764,8 @@ if (CarfieldIslandsCfg.secured.enable) begin : gen_secure_subsystem
     .async_idma_axi_out_r_data_i  ( axi_mst_ext_r_data  [SecurityIslandiDMAMstIdx] ),
     .async_idma_axi_out_r_wptr_i  ( axi_mst_ext_r_wptr  [SecurityIslandiDMAMstIdx] ),
     .async_idma_axi_out_r_rptr_o  ( axi_mst_ext_r_rptr  [SecurityIslandiDMAMstIdx] ),
-    .axi_isolate_i    ( {'0, security_island_isolate_req                    }         ),
-    .axi_isolated_o   ( { unused, master_isolated_rsp[SecurityIslandTlulMstIdx] } ),
+    .axi_isolate_i    ( security_island_isolate_req                                ),
+    .axi_isolated_o   ( { master_isolated_rsp[SecurityIslandiDMAMstIdx] master_isolated_rsp[SecurityIslandTlulMstIdx] } ),
      // Uart
     .ibex_uart_rx_i   ( uart_ot_rx_i  ),
     .ibex_uart_tx_o   ( uart_ot_tx_o  ),

--- a/hw/carfield.sv
+++ b/hw/carfield.sv
@@ -428,6 +428,7 @@ logic [    LogDepth:0] llc_w_rptr;
 
 logic hyper_isolate_req, hyper_isolated_rsp;
 logic security_island_isolate_req;
+logic unused;
 
 logic [iomsb(Cfg.AxiExtNumSlv):0] slave_isolate_req, slave_isolated_rsp, slave_isolated;
 logic [iomsb(Cfg.AxiExtNumMst):0] master_isolated_rsp;
@@ -1668,11 +1669,11 @@ if (CarfieldIslandsCfg.secured.enable) begin : gen_secure_subsystem
   assign security_island_isolate_req  = car_regs_reg2hw.security_island_isolate.q &&
                                         !secure_boot_i;
   assign car_regs_hw2reg.security_island_isolate_status.d =
-         master_isolated_rsp[SecurityIslandMstIdx];
+         master_isolated_rsp[SecurityIslandTlulMstIdx];
   assign car_regs_hw2reg.security_island_isolate_status.de = 1'b1;
 
   `ifndef SECD_NETLIST
-  secure_subsystem_synth_wrap #(
+  secure_subsystem_synth_wrap_astral #(
     .HartIdOffs            ( OpnTitHartIdOffs           ),
     .AxiAddrWidth          ( Cfg.AddrWidth              ),
     .AxiDataWidth          ( Cfg.AxiDataWidth           ),
@@ -1723,23 +1724,39 @@ if (CarfieldIslandsCfg.secured.enable) begin : gen_secure_subsystem
     .jtag_tdo_o       ( jtag_ot_tdo_o   ),
     .jtag_tdo_oe_o    ( jtag_ot_tdo_oe_o),
      // Asynch axi port
-    .async_axi_out_aw_data_o ( axi_mst_ext_aw_data [SecurityIslandMstIdx] ),
-    .async_axi_out_aw_wptr_o ( axi_mst_ext_aw_wptr [SecurityIslandMstIdx] ),
-    .async_axi_out_aw_rptr_i ( axi_mst_ext_aw_rptr [SecurityIslandMstIdx] ),
-    .async_axi_out_w_data_o  ( axi_mst_ext_w_data  [SecurityIslandMstIdx] ),
-    .async_axi_out_w_wptr_o  ( axi_mst_ext_w_wptr  [SecurityIslandMstIdx] ),
-    .async_axi_out_w_rptr_i  ( axi_mst_ext_w_rptr  [SecurityIslandMstIdx] ),
-    .async_axi_out_b_data_i  ( axi_mst_ext_b_data  [SecurityIslandMstIdx] ),
-    .async_axi_out_b_wptr_i  ( axi_mst_ext_b_wptr  [SecurityIslandMstIdx] ),
-    .async_axi_out_b_rptr_o  ( axi_mst_ext_b_rptr  [SecurityIslandMstIdx] ),
-    .async_axi_out_ar_data_o ( axi_mst_ext_ar_data [SecurityIslandMstIdx] ),
-    .async_axi_out_ar_wptr_o ( axi_mst_ext_ar_wptr [SecurityIslandMstIdx] ),
-    .async_axi_out_ar_rptr_i ( axi_mst_ext_ar_rptr [SecurityIslandMstIdx] ),
-    .async_axi_out_r_data_i  ( axi_mst_ext_r_data  [SecurityIslandMstIdx] ),
-    .async_axi_out_r_wptr_i  ( axi_mst_ext_r_wptr  [SecurityIslandMstIdx] ),
-    .async_axi_out_r_rptr_o  ( axi_mst_ext_r_rptr  [SecurityIslandMstIdx] ),
-    .axi_isolate_i    ( security_island_isolate_req                ),
-    .axi_isolated_o   ( master_isolated_rsp[SecurityIslandMstIdx] ),
+    .async_axi_out_aw_data_o ( axi_mst_ext_aw_data [SecurityIslandTlulMstIdx] ),
+    .async_axi_out_aw_wptr_o ( axi_mst_ext_aw_wptr [SecurityIslandTlulMstIdx] ),
+    .async_axi_out_aw_rptr_i ( axi_mst_ext_aw_rptr [SecurityIslandTlulMstIdx] ),
+    .async_axi_out_w_data_o  ( axi_mst_ext_w_data  [SecurityIslandTlulMstIdx] ),
+    .async_axi_out_w_wptr_o  ( axi_mst_ext_w_wptr  [SecurityIslandTlulMstIdx] ),
+    .async_axi_out_w_rptr_i  ( axi_mst_ext_w_rptr  [SecurityIslandTlulMstIdx] ),
+    .async_axi_out_b_data_i  ( axi_mst_ext_b_data  [SecurityIslandTlulMstIdx] ),
+    .async_axi_out_b_wptr_i  ( axi_mst_ext_b_wptr  [SecurityIslandTlulMstIdx] ),
+    .async_axi_out_b_rptr_o  ( axi_mst_ext_b_rptr  [SecurityIslandTlulMstIdx] ),
+    .async_axi_out_ar_data_o ( axi_mst_ext_ar_data [SecurityIslandTlulMstIdx] ),
+    .async_axi_out_ar_wptr_o ( axi_mst_ext_ar_wptr [SecurityIslandTlulMstIdx] ),
+    .async_axi_out_ar_rptr_i ( axi_mst_ext_ar_rptr [SecurityIslandTlulMstIdx] ),
+    .async_axi_out_r_data_i  ( axi_mst_ext_r_data  [SecurityIslandTlulMstIdx] ),
+    .async_axi_out_r_wptr_i  ( axi_mst_ext_r_wptr  [SecurityIslandTlulMstIdx] ),
+    .async_axi_out_r_rptr_o  ( axi_mst_ext_r_rptr  [SecurityIslandTlulMstIdx] ),
+
+    .async_idma_axi_out_aw_data_o ( axi_mst_ext_aw_data [SecurityIslandiDMAMstIdx] ),
+    .async_idma_axi_out_aw_wptr_o ( axi_mst_ext_aw_wptr [SecurityIslandiDMAMstIdx] ),
+    .async_idma_axi_out_aw_rptr_i ( axi_mst_ext_aw_rptr [SecurityIslandiDMAMstIdx] ),
+    .async_idma_axi_out_w_data_o  ( axi_mst_ext_w_data  [SecurityIslandiDMAMstIdx] ),
+    .async_idma_axi_out_w_wptr_o  ( axi_mst_ext_w_wptr  [SecurityIslandiDMAMstIdx] ),
+    .async_idma_axi_out_w_rptr_i  ( axi_mst_ext_w_rptr  [SecurityIslandiDMAMstIdx] ),
+    .async_idma_axi_out_b_data_i  ( axi_mst_ext_b_data  [SecurityIslandiDMAMstIdx] ),
+    .async_idma_axi_out_b_wptr_i  ( axi_mst_ext_b_wptr  [SecurityIslandiDMAMstIdx] ),
+    .async_idma_axi_out_b_rptr_o  ( axi_mst_ext_b_rptr  [SecurityIslandiDMAMstIdx] ),
+    .async_idma_axi_out_ar_data_o ( axi_mst_ext_ar_data [SecurityIslandiDMAMstIdx] ),
+    .async_idma_axi_out_ar_wptr_o ( axi_mst_ext_ar_wptr [SecurityIslandiDMAMstIdx] ),
+    .async_idma_axi_out_ar_rptr_i ( axi_mst_ext_ar_rptr [SecurityIslandiDMAMstIdx] ),
+    .async_idma_axi_out_r_data_i  ( axi_mst_ext_r_data  [SecurityIslandiDMAMstIdx] ),
+    .async_idma_axi_out_r_wptr_i  ( axi_mst_ext_r_wptr  [SecurityIslandiDMAMstIdx] ),
+    .async_idma_axi_out_r_rptr_o  ( axi_mst_ext_r_rptr  [SecurityIslandiDMAMstIdx] ),
+    .axi_isolate_i    ( {'0, security_island_isolate_req                    }         ),
+    .axi_isolated_o   ( { unused, master_isolated_rsp[SecurityIslandTlulMstIdx] } ),
      // Uart
     .ibex_uart_rx_i   ( uart_ot_rx_i  ),
     .ibex_uart_tx_o   ( uart_ot_tx_o  ),
@@ -1750,7 +1767,9 @@ if (CarfieldIslandsCfg.secured.enable) begin : gen_secure_subsystem
     .spi_host_CSB_en_o( spih_ot_csb_en_o ),
     .spi_host_SD_o    ( spih_ot_sd_o     ),
     .spi_host_SD_i    ( spih_ot_sd_i     ),
-    .spi_host_SD_en_o ( spih_ot_sd_en_o  )
+    .spi_host_SD_en_o ( spih_ot_sd_en_o  ),
+    .gpio_0_i         ( '0               ),
+    .gpio_1_i         ( '0               )
   );
 end else begin : gen_no_secure_subsystem
   assign hostd_secd_mbox_intr = '0;

--- a/hw/carfield.sv
+++ b/hw/carfield.sv
@@ -1668,7 +1668,8 @@ if (CarfieldIslandsCfg.secured.enable) begin : gen_secure_subsystem
   assign security_island_isolate_req  = car_regs_reg2hw.security_island_isolate.q &&
                                         !secure_boot_i;
   assign car_regs_hw2reg.security_island_isolate_status.d =
-         master_isolated_rsp[SecurityIslandTlulMstIdx] & master_isolated_rsp[SecurityIslandiDMAMstIdx];
+         master_isolated_rsp[SecurityIslandTlulMstIdx] 
+         & master_isolated_rsp[SecurityIslandiDMAMstIdx];
   assign car_regs_hw2reg.security_island_isolate_status.de = 1'b1;
 
   typedef logic [Cfg.AddrWidth-1:0]        narrow_axi_addr_t;
@@ -1764,7 +1765,8 @@ if (CarfieldIslandsCfg.secured.enable) begin : gen_secure_subsystem
     .async_idma_axi_out_r_wptr_i  ( axi_mst_ext_r_wptr  [SecurityIslandiDMAMstIdx] ),
     .async_idma_axi_out_r_rptr_o  ( axi_mst_ext_r_rptr  [SecurityIslandiDMAMstIdx] ),
     .axi_isolate_i    ( security_island_isolate_req                                ),
-    .axi_isolated_o   ( { master_isolated_rsp[SecurityIslandiDMAMstIdx], master_isolated_rsp[SecurityIslandTlulMstIdx] } ),
+    .axi_isolated_o   ( { master_isolated_rsp[SecurityIslandiDMAMstIdx],
+                          master_isolated_rsp[SecurityIslandTlulMstIdx] }          ),
      // Uart
     .ibex_uart_rx_i   ( uart_ot_rx_i  ),
     .ibex_uart_tx_o   ( uart_ot_tx_o  ),

--- a/hw/carfield_pkg.sv
+++ b/hw/carfield_pkg.sv
@@ -40,6 +40,7 @@ typedef struct packed {
   islands_properties_t spatz;
   islands_properties_t pulp;
   islands_properties_t secured;
+  islands_properties_t secured_idma;
   islands_properties_t mbox;
 } islands_cfg_t;
 
@@ -122,10 +123,10 @@ endfunction
 // crossbar starting from the islands enable structure.
 function automatic int unsigned gen_num_axi_master(islands_cfg_t island_cfg);
   int unsigned ret = 0; // Number of masters starts from 0
-  if (island_cfg.safed.enable  )      begin ret++; end
-  if (island_cfg.spatz.enable  )      begin ret++; end
-  if (island_cfg.pulp.enable   )      begin ret++; end
-  if (island_cfg.secured.enable)      begin ret+=2; end
+  if (island_cfg.safed.enable  ) begin ret++; end
+  if (island_cfg.spatz.enable  ) begin ret++; end
+  if (island_cfg.pulp.enable   ) begin ret++; end
+  if (island_cfg.secured.enable) begin ret+=2; end
   return ret;
 endfunction
 

--- a/hw/carfield_pkg.sv
+++ b/hw/carfield_pkg.sv
@@ -41,6 +41,7 @@ typedef struct packed {
   islands_properties_t pulp;
   islands_properties_t secured;
   islands_properties_t mbox;
+  islands_properties_t secured_idma;
 } islands_cfg_t;
 
 // Types are obtained from Cheshire package
@@ -71,6 +72,7 @@ typedef struct packed {
   byte_bt spatz;
   byte_bt secured;
   byte_bt pulp;
+  byte_bt secured_idma;
 } carfield_master_idx_t;
 
 // Generate the number of AXI slave devices to be connected to the
@@ -316,15 +318,16 @@ function automatic int unsigned gen_carfield_domains(islands_cfg_t island_cfg);
 endfunction
 
 localparam islands_cfg_t CarfieldIslandsCfg = '{
-  l2_port0: '{L2Port0Enable, L2Port0Base, L2Port0Size},
-  l2_port1: '{L2Port1Enable, L2Port1Base, L2Port1Size},
-  safed:    '{SafetyIslandEnable, SafetyIslandBase, SafetyIslandSize},
-  ethernet: '{EthernetEnable, EthernetBase, EthernetSize},
-  periph:   '{PeriphEnable, PeriphBase, PeriphSize},
-  spatz:    '{SpatzClusterEnable, SpatzClusterBase, SpatzClusterSize},
-  pulp:     '{PulpClusterEnable, PulpClusterBase, PulpClusterSize},
-  secured:  '{SecurityIslandEnable, SecurityIslandBase, SecurityIslandSize},
-  mbox:     '{MailboxEnable, MailboxBase, MailboxSize}
+  l2_port0:      '{L2Port0Enable, L2Port0Base, L2Port0Size},
+  l2_port1:      '{L2Port1Enable, L2Port1Base, L2Port1Size},
+  safed:         '{SafetyIslandEnable, SafetyIslandBase, SafetyIslandSize},
+  ethernet:      '{EthernetEnable, EthernetBase, EthernetSize},
+  periph:        '{PeriphEnable, PeriphBase, PeriphSize},
+  spatz:         '{SpatzClusterEnable, SpatzClusterBase, SpatzClusterSize},
+  pulp:          '{PulpClusterEnable, PulpClusterBase, PulpClusterSize},
+  secured:       '{SecurityIslandEnable, SecurityIslandBase, SecurityIslandSize},
+  mbox:          '{MailboxEnable, MailboxBase, MailboxSize},
+  secured_idma:  '{SecurityIslandEnable, SecurityIslandBase, SecurityIslandSize}
 };
 
 localparam int unsigned CarfieldAxiNumSlaves  = gen_num_axi_slave(CarfieldIslandsCfg);
@@ -416,10 +419,11 @@ typedef enum byte_bt {
 } axi_slv_idx_t;
 
 typedef enum byte_bt {
-  SafetyIslandMstIdx   = CarfieldMstIdx.safed,
-  SecurityIslandMstIdx = CarfieldMstIdx.secured,
-  FPClusterMstIdx      = CarfieldMstIdx.spatz,
-  IntClusterMstIdx     = CarfieldMstIdx.pulp
+  SafetyIslandMstIdx       = CarfieldMstIdx.safed,
+  SecurityIslandTlulMstIdx = CarfieldMstIdx.secured,
+  FPClusterMstIdx          = CarfieldMstIdx.spatz,
+  IntClusterMstIdx         = CarfieldMstIdx.pulp,
+  SecurityIslandiDMAMstIdx = CarfieldMstIdx.secured_idma
 } axi_mst_idx_t;
 
 // APB peripherals

--- a/hw/carfield_pkg.sv
+++ b/hw/carfield_pkg.sv
@@ -71,8 +71,8 @@ typedef struct packed {
   byte_bt safed;
   byte_bt spatz;
   byte_bt secured;
-  byte_bt pulp;
   byte_bt secured_idma;
+  byte_bt pulp;
 } carfield_master_idx_t;
 
 // Generate the number of AXI slave devices to be connected to the
@@ -123,10 +123,11 @@ endfunction
 // crossbar starting from the islands enable structure.
 function automatic int unsigned gen_num_axi_master(islands_cfg_t island_cfg);
   int unsigned ret = 0; // Number of masters starts from 0
-  if (island_cfg.safed.enable  ) begin ret++; end
-  if (island_cfg.spatz.enable  ) begin ret++; end
-  if (island_cfg.pulp.enable   ) begin ret++; end
-  if (island_cfg.secured.enable) begin ret++; end
+  if (island_cfg.safed.enable  )      begin ret++; end
+  if (island_cfg.spatz.enable  )      begin ret++; end
+  if (island_cfg.pulp.enable   )      begin ret++; end
+  if (island_cfg.secured.enable)      begin ret++; end
+  if (island_cfg.secured.enable)      begin ret++; end
   return ret;
 endfunction
 
@@ -142,6 +143,8 @@ function automatic carfield_master_idx_t carfield_gen_axi_master_idx(islands_cfg
   end else begin ret.secured = MaxExtAxiMst + j; j++; end
   if (island_cfg.spatz.enable) begin ret.spatz = i; i++;
   end else begin ret.spatz = MaxExtAxiMst + j; j++; end
+  if (island_cfg.secured.enable) begin ret.secured_idma = i; i++;
+  end else begin ret.secured_idma = MaxExtAxiMst + j; j++; end
   if (island_cfg.pulp.enable) begin ret.pulp = i; i++;
   end else begin ret.pulp = MaxExtAxiMst + j; j++; end
   return ret;
@@ -422,8 +425,8 @@ typedef enum byte_bt {
   SafetyIslandMstIdx       = CarfieldMstIdx.safed,
   SecurityIslandTlulMstIdx = CarfieldMstIdx.secured,
   FPClusterMstIdx          = CarfieldMstIdx.spatz,
-  IntClusterMstIdx         = CarfieldMstIdx.pulp,
-  SecurityIslandiDMAMstIdx = CarfieldMstIdx.secured_idma
+  SecurityIslandiDMAMstIdx = CarfieldMstIdx.secured_idma,
+  IntClusterMstIdx         = CarfieldMstIdx.pulp
 } axi_mst_idx_t;
 
 // APB peripherals

--- a/hw/carfield_pkg.sv
+++ b/hw/carfield_pkg.sv
@@ -40,7 +40,6 @@ typedef struct packed {
   islands_properties_t spatz;
   islands_properties_t pulp;
   islands_properties_t secured;
-  islands_properties_t secured_idma;
   islands_properties_t mbox;
 } islands_cfg_t;
 
@@ -326,8 +325,7 @@ localparam islands_cfg_t CarfieldIslandsCfg = '{
   spatz:         '{SpatzClusterEnable, SpatzClusterBase, SpatzClusterSize},
   pulp:          '{PulpClusterEnable, PulpClusterBase, PulpClusterSize},
   secured:       '{SecurityIslandEnable, SecurityIslandBase, SecurityIslandSize},
-  mbox:          '{MailboxEnable, MailboxBase, MailboxSize},
-  secured_idma:  '{SecurityIslandEnable, SecurityIslandBase, SecurityIslandSize}
+  mbox:          '{MailboxEnable, MailboxBase, MailboxSize}
 };
 
 localparam int unsigned CarfieldAxiNumSlaves  = gen_num_axi_slave(CarfieldIslandsCfg);

--- a/hw/carfield_pkg.sv
+++ b/hw/carfield_pkg.sv
@@ -41,7 +41,6 @@ typedef struct packed {
   islands_properties_t pulp;
   islands_properties_t secured;
   islands_properties_t mbox;
-  islands_properties_t secured_idma;
 } islands_cfg_t;
 
 // Types are obtained from Cheshire package
@@ -126,8 +125,7 @@ function automatic int unsigned gen_num_axi_master(islands_cfg_t island_cfg);
   if (island_cfg.safed.enable  )      begin ret++; end
   if (island_cfg.spatz.enable  )      begin ret++; end
   if (island_cfg.pulp.enable   )      begin ret++; end
-  if (island_cfg.secured.enable)      begin ret++; end
-  if (island_cfg.secured.enable)      begin ret++; end
+  if (island_cfg.secured.enable)      begin ret+=2; end
   return ret;
 endfunction
 
@@ -139,12 +137,10 @@ function automatic carfield_master_idx_t carfield_gen_axi_master_idx(islands_cfg
   byte_bt j = 0;
   if (island_cfg.safed.enable) begin ret.safed = i; i++;
   end else begin ret.safed = MaxExtAxiMst + j; j++; end
-  if (island_cfg.secured.enable) begin ret.secured = i; i++;
-  end else begin ret.secured = MaxExtAxiMst + j; j++; end
+  if (island_cfg.secured.enable) begin ret.secured = i; ret.secured_idma = i+1; i+=2;
+  end else begin ret.secured = MaxExtAxiMst + j; ret.secured_idma = MaxExtAxiMst + j + 1; j+=2; end
   if (island_cfg.spatz.enable) begin ret.spatz = i; i++;
   end else begin ret.spatz = MaxExtAxiMst + j; j++; end
-  if (island_cfg.secured.enable) begin ret.secured_idma = i; i++;
-  end else begin ret.secured_idma = MaxExtAxiMst + j; j++; end
   if (island_cfg.pulp.enable) begin ret.pulp = i; i++;
   end else begin ret.pulp = MaxExtAxiMst + j; j++; end
   return ret;
@@ -424,8 +420,8 @@ typedef enum byte_bt {
 typedef enum byte_bt {
   SafetyIslandMstIdx       = CarfieldMstIdx.safed,
   SecurityIslandTlulMstIdx = CarfieldMstIdx.secured,
-  FPClusterMstIdx          = CarfieldMstIdx.spatz,
   SecurityIslandiDMAMstIdx = CarfieldMstIdx.secured_idma,
+  FPClusterMstIdx          = CarfieldMstIdx.spatz,
   IntClusterMstIdx         = CarfieldMstIdx.pulp
 } axi_mst_idx_t;
 


### PR DESCRIPTION
Bumping OpenTitan to a ligher version: 
- 32KB of SRAM and 64KB of emulated flash.
- iDMA and TCDM integration, dedicated to cryptographic accelrators
- integrated into carfield the new AXI4 port for opentitan's iDMA