### PR TITLE
Move AXI ID remappers into PULP cluster.

### DIFF
--- a/Bender.lock
+++ b/Bender.lock
@@ -369,7 +369,7 @@ packages:
     - axi
     - common_verification
   pulp_cluster:
-    revision: 3d3a8691a1fd87966835e89a64d4d370b379f402
+    revision: 3cd3e83fdd7a791e8ae54aef39423004581c8a48
     version: null
     source:
       Git: https://github.com/pulp-platform/pulp_cluster.git

--- a/Bender.lock
+++ b/Bender.lock
@@ -22,8 +22,8 @@ packages:
     - apb
     - register_interface
   axi:
-    revision: fccffb5953ec8564218ba05e20adbedec845e014
-    version: 0.39.1
+    revision: ac5deb3ff086aa34b168f392c051e92603d6c0e2
+    version: 0.39.2
     source:
       Git: https://github.com/pulp-platform/axi.git
     dependencies:
@@ -91,8 +91,8 @@ packages:
     dependencies:
     - common_cells
   axi_vga:
-    revision: 07be187d1e954d8090031b32d236ad76dc62ce45
-    version: 0.1.1
+    revision: 3718b9930f94a9eaad8ee50b4bccc71df0403084
+    version: 0.1.3
     source:
       Git: https://github.com/pulp-platform/axi_vga.git
     dependencies:
@@ -162,8 +162,8 @@ packages:
     dependencies:
     - hci
   common_cells:
-    revision: 13f28aa0021fc22c0d01a12d618fda58d2c93239
-    version: 1.33.0
+    revision: ad22699793d98ef714f120c6268fe92d096a61e1
+    version: 1.33.1
     source:
       Git: https://github.com/pulp-platform/common_cells.git
     dependencies:
@@ -330,8 +330,8 @@ packages:
     dependencies:
     - common_cells
   obi:
-    revision: d04f1706ba5b7731bbc0a3a085e725e29fcc5b8e
-    version: 0.1.1
+    revision: 1aa411df145c4ebdd61f8fed4d003c33f7b20636
+    version: 0.1.2
     source:
       Git: https://github.com/pulp-platform/obi.git
     dependencies:
@@ -419,8 +419,8 @@ packages:
     - register_interface
     - tech_cells_generic
   register_interface:
-    revision: e25b36670ff7aab3402f40efcc2b11ee0f31cf19
-    version: 0.4.3
+    revision: ae616e5a1ec2b41e72d200e5ab09c65e94aebd3d
+    version: 0.4.4
     source:
       Git: https://github.com/pulp-platform/register_interface.git
     dependencies:

--- a/Bender.yml
+++ b/Bender.yml
@@ -17,7 +17,7 @@ dependencies:
   hyperbus:           { git: https://github.com/pulp-platform/hyperbus.git,             rev: f039e601c8b6590181734e6d26ff8b77aa380412 } # branch: chi/add_fsm_with_Tcsh
   dyn_mem:            { git: https://github.com/pulp-platform/dyn_spm.git,              rev: 480590062742230dc9bd4050358a15b4747bdf34 } # branch: main
   safety_island:      { git: https://github.com/pulp-platform/safety_island.git,        rev: aaef55c798ab53560faaf451a86668fa1e6d0f3b } # branch: carfield
-  pulp_cluster:       { git: https://github.com/pulp-platform/pulp_cluster.git,         rev: 3d3a8691a1fd87966835e89a64d4d370b379f402 } # branch: astral
+  pulp_cluster:       { git: https://github.com/pulp-platform/pulp_cluster.git,         rev: 3cd3e83fdd7a791e8ae54aef39423004581c8a48 } # branch: idw-conv
   opentitan:          { git: https://github.com/pulp-platform/opentitan.git,            rev: 74e7d6ca17e6a46e727ae2ae11177611232eaeb9 } # branch: carfield_soc
   mailbox_unit:       { git: https://github.com/pulp-platform/mailbox_unit.git,         version: 1.1.0                                }
   apb:                { git: https://github.com/pulp-platform/apb.git,                  version: 0.2.3                                }

--- a/hw/carfield_pkg.sv
+++ b/hw/carfield_pkg.sv
@@ -676,69 +676,10 @@ localparam int unsigned SafetyIslandPerOffset = 'h0020_0000;
 /******************************/
 /* Integer Cluster Parameters */
 /******************************/
-localparam int unsigned IntClusterNumCacheBanks = 2;
-localparam int unsigned IntClusterNumAxiMst = 3;
-localparam int unsigned IntClusterNumAxiSlv = 4;
-// // IntClusterAxiIdInWidth is fixed from PULP Cluster
-localparam int unsigned IntClusterAxiIdInWidth = $clog2(IntClusterNumCacheBanks) + 3;
-localparam int unsigned IntClusterAxiIdOutWidth = IntClusterAxiIdInWidth     +
-                                                  $clog2(IntClusterNumAxiSlv);
-localparam bit[CarfieldCfgDefault.AddrWidth-1:0] ClustPeriphOffs = 'h00200000;
-localparam bit[CarfieldCfgDefault.AddrWidth-1:0] ClustExtOffs    = 'h00400000;
-localparam int unsigned IntClusterMaxUniqId = 1;
+localparam bit[CarfieldCfgDefault.AddrWidth-1:0] PulpClustPeriphOffs = 'h00200000;
+localparam bit[CarfieldCfgDefault.AddrWidth-1:0] PulpClustExtOffs    = 'h00400000;
 localparam int unsigned IntClusterNumEoc = 1;
 localparam logic [ 5:0] IntClusterIndex = (PulpHartIdOffs >> 5);
-localparam pulp_cluster_package::pulp_cluster_cfg_t PulpClusterCfg = '{
-  CoreType: pulp_cluster_package::RISCY,
-  NumCores: 12,
-  DmaNumPlugs: 4,
-  DmaNumOutstandingBursts: 8,
-  DmaBurstLength: 256,
-  NumMstPeriphs: 1,
-  NumSlvPeriphs: 10,
-  ClusterAlias: 1,
-  ClusterAliasBase: 'h0,
-  NumSyncStages: 3,
-  UseHci: 1,
-  TcdmSize: 256*1024,
-  TcdmNumBank: 16,
-  HwpePresent: 1,
-  HwpeNumPorts: 9,
-  iCacheNumBanks: IntClusterNumCacheBanks,
-  iCacheNumLines: 1,
-  iCacheNumWays: 4,
-  iCacheSharedSize: 4*1024,
-  iCachePrivateSize: 512,
-  iCachePrivateDataWidth: 32,
-  EnableReducedTag: 1,
-  L2Size: L2MemSize,
-  DmBaseAddr: CarfieldIslandsCfg.safed.base+
-              SafetyIslandPerOffset+
-              safety_island_pkg::DebugAddrOffset,
-  BootRomBaseAddr: CarfieldIslandsCfg.l2_port0.base + 'h8080,
-  BootAddr: CarfieldIslandsCfg.l2_port0.base + 'h8080,
-  EnablePrivateFpu: 0,
-  EnablePrivateFpDivSqrt: 0,
-  EnableSharedFpu: 0,
-  EnableSharedFpDivSqrt: 0,
-  NumSharedFpu: 0,
-  NumAxiIn: IntClusterNumAxiSlv,
-  NumAxiOut: IntClusterNumAxiMst,
-  AxiIdInWidth: IntClusterAxiIdInWidth,
-  AxiIdOutWidth:IntClusterAxiIdOutWidth,
-  AxiAddrWidth: CarfieldCfgDefault.AddrWidth,
-  AxiDataInWidth:  CarfieldCfgDefault.AxiDataWidth,
-  AxiDataOutWidth: CarfieldCfgDefault.AxiDataWidth,
-  AxiUserWidth: CarfieldCfgDefault.AxiUserWidth,
-  AxiCdcLogDepth: 3,
-  AxiCdcSyncStages: SyncStages,
-  SyncStages: SyncStages,
-  ClusterBaseAddr: CarfieldAxiMap.AxiStart[CarfieldAxiSlvIdx.pulp],
-  ClusterPeriphOffs: ClustPeriphOffs,
-  ClusterExternalOffs: ClustExtOffs,
-  EnableRemapAddress: 0,
-  default: '0
-};
 
 /*************************************/
 /* Floating Point Cluster Parameters */
@@ -757,8 +698,6 @@ localparam int unsigned AxiNarrowStrobe    = AxiNarrowDataWidth/8;
 typedef logic [     AxiNarrowAddrWidth-1:0] car_nar_addrw_t;
 typedef logic [     AxiNarrowDataWidth-1:0] car_nar_dataw_t;
 typedef logic [        AxiNarrowStrobe-1:0] car_nar_strb_t;
-typedef logic [ IntClusterAxiIdInWidth-1:0] intclust_idin_t;
-typedef logic [IntClusterAxiIdOutWidth-1:0] intclust_idout_t;
 
 // APB Mapping
 localparam int unsigned NumApbMst = 5;

--- a/hw/cheshire_wrap.sv
+++ b/hw/cheshire_wrap.sv
@@ -39,20 +39,6 @@ module cheshire_wrap
   parameter type cheshire_axi_ext_slv_w_chan_t  = logic,
   parameter type cheshire_axi_ext_slv_req_t     = logic,
   parameter type cheshire_axi_ext_slv_rsp_t     = logic,
-  parameter type axi_intcluster_slv_ar_chan_t   = logic,
-  parameter type axi_intcluster_slv_aw_chan_t   = logic,
-  parameter type axi_intcluster_slv_b_chan_t    = logic,
-  parameter type axi_intcluster_slv_r_chan_t    = logic,
-  parameter type axi_intcluster_slv_w_chan_t    = logic,
-  parameter type axi_intcluster_slv_req_t       = logic,
-  parameter type axi_intcluster_slv_rsp_t       = logic,
-  parameter type axi_intcluster_mst_ar_chan_t   = logic,
-  parameter type axi_intcluster_mst_aw_chan_t   = logic,
-  parameter type axi_intcluster_mst_b_chan_t    = logic,
-  parameter type axi_intcluster_mst_r_chan_t    = logic,
-  parameter type axi_intcluster_mst_w_chan_t    = logic,
-  parameter type axi_intcluster_mst_req_t       = logic,
-  parameter type axi_intcluster_mst_rsp_t       = logic,
   parameter type cheshire_reg_ext_req_t         = logic,
   parameter type cheshire_reg_ext_rsp_t         = logic,
   parameter int unsigned LogDepth = 3,
@@ -82,10 +68,8 @@ module cheshire_wrap
                                         axi_pkg::w_width(Cfg.AxiDataWidth,
                                                          Cfg.AxiUserWidth),
   // External Slaves Parameters
-  localparam int unsigned NumExcludedSlaves = CarfieldIslandsCfg.pulp.enable ? 2 : 1,
-  localparam int unsigned NumSlaveCDCs = Cfg.AxiExtNumSlv - NumExcludedSlaves,
-  localparam int unsigned NumExcludedIsolate = CarfieldIslandsCfg.pulp.enable ? 1 : 0,
-  localparam int unsigned NumIsolate = Cfg.AxiExtNumSlv - NumExcludedIsolate,
+  // Having a dedicated synchronous port, the mailbox is not taken into account
+  localparam int unsigned NumSlaveCDCs = Cfg.AxiExtNumSlv - 1,
   localparam int unsigned ExtSlvIdWidth = Cfg.AxiMstIdWidth   +
                                           $clog2(AxiIn.num_in ),
   localparam int unsigned ExtSlvArWidth = (2**LogDepth)*
@@ -107,8 +91,6 @@ module cheshire_wrap
                                            axi_pkg::w_width(Cfg.AxiDataWidth,
                                                             Cfg.AxiUserWidth),
   // External Master Parameters
-  localparam int unsigned NumExcludedMasters = CarfieldIslandsCfg.pulp.enable ? 1 : 0,
-  localparam int unsigned NumMasterCDCs = Cfg.AxiExtNumMst - NumExcludedMasters,
   localparam int unsigned ExtMstArWidth = (2**LogDepth)*
                                            axi_pkg::ar_width(Cfg.AddrWidth    ,
                                                              Cfg.AxiMstIdWidth,
@@ -126,45 +108,7 @@ module cheshire_wrap
                                                             Cfg.AxiUserWidth ),
   localparam int unsigned ExtMstWWidth  = (2**LogDepth)*
                                            axi_pkg::w_width(Cfg.AxiDataWidth,
-                                                            Cfg.AxiUserWidth),
-  // Integer Cluster slave parameters
-  localparam int unsigned IntClusterAxiSlvAwWidth =
-                          (2**LogDepth)*axi_pkg::aw_width(Cfg.AddrWidth         ,
-                                                          IntClusterAxiIdInWidth,
-                                                          Cfg.AxiUserWidth      ),
-  localparam int unsigned IntClusterAxiSlvWWidth  =
-                          (2**LogDepth)*axi_pkg::w_width(Cfg.AxiDataWidth,
-                                                         Cfg.AxiUserWidth),
-  localparam int unsigned IntClusterAxiSlvBWidth  =
-                          (2**LogDepth)*axi_pkg::b_width(IntClusterAxiIdInWidth,
-                                                         Cfg.AxiUserWidth      ),
-  localparam int unsigned IntClusterAxiSlvArWidth =
-                          (2**LogDepth)*axi_pkg::ar_width(Cfg.AddrWidth         ,
-                                                          IntClusterAxiIdInWidth,
-                                                          Cfg.AxiUserWidth      ),
-  localparam int unsigned IntClusterAxiSlvRWidth  =
-                          (2**LogDepth)*axi_pkg::r_width(Cfg.AxiDataWidth      ,
-                                                         IntClusterAxiIdInWidth,
-                                                         Cfg.AxiUserWidth      ),
-  // Integer Cluster Master parameters
-  localparam int unsigned IntClusterAxiMstAwWidth =
-                          (2**LogDepth)*axi_pkg::aw_width(Cfg.AddrWidth          ,
-                                                          IntClusterAxiIdOutWidth,
-                                                          Cfg.AxiUserWidth       ),
-  localparam int unsigned IntClusterAxiMstWWidth  =
-                          (2**LogDepth)*axi_pkg::w_width(Cfg.AxiDataWidth,
-                                                         Cfg.AxiUserWidth),
-  localparam int unsigned IntClusterAxiMstBWidth  =
-                          (2**LogDepth)*axi_pkg::b_width(IntClusterAxiIdOutWidth,
-                                                        Cfg.AxiUserWidth        ),
-  localparam int unsigned IntClusterAxiMstArWidth =
-                          (2**LogDepth)*axi_pkg::ar_width(Cfg.AddrWidth          ,
-                                                          IntClusterAxiIdOutWidth,
-                                                          Cfg.AxiUserWidth       ),
-  localparam int unsigned IntClusterAxiMstRWidth  =
-                          (2**LogDepth)*axi_pkg::r_width(Cfg.AxiDataWidth       ,
-                                                         IntClusterAxiIdOutWidth,
-                                                         Cfg.AxiUserWidth       )
+                                                            Cfg.AxiUserWidth)
 )(
   input  logic        clk_i      ,
   input  logic        rst_ni     ,
@@ -190,8 +134,8 @@ module cheshire_wrap
   output logic [    LogDepth:0] llc_mst_w_wptr_o ,
   input  logic [    LogDepth:0] llc_mst_w_rptr_i ,
   // External AXI isolate slave Ports (except the Mailbox)
-  input  logic [iomsb(NumIsolate):0]                    axi_ext_slv_isolate_i,
-  output logic [iomsb(NumIsolate):0]                    axi_ext_slv_isolated_o,
+  input  logic [iomsb(Cfg.AxiExtNumSlv):0]                axi_ext_slv_isolate_i,
+  output logic [iomsb(Cfg.AxiExtNumSlv):0]                axi_ext_slv_isolated_o,
   // External async AXI slave Ports (except the Integer Cluster and the Mailbox)
   output logic [iomsb(NumSlaveCDCs):0][ExtSlvArWidth-1:0] axi_ext_slv_ar_data_o,
   output logic [iomsb(NumSlaveCDCs):0][       LogDepth:0] axi_ext_slv_ar_wptr_o,
@@ -209,53 +153,21 @@ module cheshire_wrap
   output logic [iomsb(NumSlaveCDCs):0][       LogDepth:0] axi_ext_slv_w_wptr_o ,
   input  logic [iomsb(NumSlaveCDCs):0][       LogDepth:0] axi_ext_slv_w_rptr_i ,
   // External async AXI master Ports (except the Integer Cluster)
-  input  logic [iomsb(NumMasterCDCs):0][ExtMstArWidth-1:0] axi_ext_mst_ar_data_i,
-  input  logic [iomsb(NumMasterCDCs):0][       LogDepth:0] axi_ext_mst_ar_wptr_i,
-  output logic [iomsb(NumMasterCDCs):0][       LogDepth:0] axi_ext_mst_ar_rptr_o,
-  input  logic [iomsb(NumMasterCDCs):0][ExtMstAwWidth-1:0] axi_ext_mst_aw_data_i,
-  input  logic [iomsb(NumMasterCDCs):0][       LogDepth:0] axi_ext_mst_aw_wptr_i,
-  output logic [iomsb(NumMasterCDCs):0][       LogDepth:0] axi_ext_mst_aw_rptr_o,
-  output logic [iomsb(NumMasterCDCs):0][ ExtMstBWidth-1:0] axi_ext_mst_b_data_o ,
-  output logic [iomsb(NumMasterCDCs):0][       LogDepth:0] axi_ext_mst_b_wptr_o ,
-  input  logic [iomsb(NumMasterCDCs):0][       LogDepth:0] axi_ext_mst_b_rptr_i ,
-  output logic [iomsb(NumMasterCDCs):0][ ExtMstRWidth-1:0] axi_ext_mst_r_data_o ,
-  output logic [iomsb(NumMasterCDCs):0][       LogDepth:0] axi_ext_mst_r_wptr_o ,
-  input  logic [iomsb(NumMasterCDCs):0][       LogDepth:0] axi_ext_mst_r_rptr_i ,
-  input  logic [iomsb(NumMasterCDCs):0][ ExtMstWWidth-1:0] axi_ext_mst_w_data_i ,
-  input  logic [iomsb(NumMasterCDCs):0][       LogDepth:0] axi_ext_mst_w_wptr_i ,
-  output logic [iomsb(NumMasterCDCs):0][       LogDepth:0] axi_ext_mst_w_rptr_o ,
-  // Integer Cluster async Slave Port
-  output logic [IntClusterAxiSlvAwWidth-1:0] axi_slv_intcluster_aw_data_o,
-  output logic [                 LogDepth:0] axi_slv_intcluster_aw_wptr_o,
-  input  logic [                 LogDepth:0] axi_slv_intcluster_aw_rptr_i,
-  output logic [ IntClusterAxiSlvWWidth-1:0] axi_slv_intcluster_w_data_o ,
-  output logic [                 LogDepth:0] axi_slv_intcluster_w_wptr_o ,
-  input  logic [                 LogDepth:0] axi_slv_intcluster_w_rptr_i ,
-  input  logic [ IntClusterAxiSlvBWidth-1:0] axi_slv_intcluster_b_data_i ,
-  input  logic [                 LogDepth:0] axi_slv_intcluster_b_wptr_i ,
-  output logic [                 LogDepth:0] axi_slv_intcluster_b_rptr_o ,
-  output logic [IntClusterAxiSlvArWidth-1:0] axi_slv_intcluster_ar_data_o,
-  output logic [                 LogDepth:0] axi_slv_intcluster_ar_wptr_o,
-  input  logic [                 LogDepth:0] axi_slv_intcluster_ar_rptr_i,
-  input  logic [ IntClusterAxiSlvRWidth-1:0] axi_slv_intcluster_r_data_i ,
-  input  logic [                 LogDepth:0] axi_slv_intcluster_r_wptr_i ,
-  output logic [                 LogDepth:0] axi_slv_intcluster_r_rptr_o ,
-  // Integer Cluster async Master Port
-  input  logic [IntClusterAxiMstAwWidth-1:0] axi_mst_intcluster_aw_data_i,
-  input  logic [                 LogDepth:0] axi_mst_intcluster_aw_wptr_i,
-  output logic [                 LogDepth:0] axi_mst_intcluster_aw_rptr_o,
-  input  logic [ IntClusterAxiMstWWidth-1:0] axi_mst_intcluster_w_data_i ,
-  input  logic [                 LogDepth:0] axi_mst_intcluster_w_wptr_i ,
-  output logic [                 LogDepth:0] axi_mst_intcluster_w_rptr_o ,
-  output logic [ IntClusterAxiMstBWidth-1:0] axi_mst_intcluster_b_data_o ,
-  output logic [                 LogDepth:0] axi_mst_intcluster_b_wptr_o ,
-  input  logic [                 LogDepth:0] axi_mst_intcluster_b_rptr_i ,
-  input  logic [IntClusterAxiMstArWidth-1:0] axi_mst_intcluster_ar_data_i,
-  input  logic [                 LogDepth:0] axi_mst_intcluster_ar_wptr_i,
-  output logic [                 LogDepth:0] axi_mst_intcluster_ar_rptr_o,
-  output logic [ IntClusterAxiMstRWidth-1:0] axi_mst_intcluster_r_data_o ,
-  output logic [                 LogDepth:0] axi_mst_intcluster_r_wptr_o ,
-  input  logic [                 LogDepth:0] axi_mst_intcluster_r_rptr_i ,
+  input  logic [iomsb(Cfg.AxiExtNumMst):0][ExtMstArWidth-1:0] axi_ext_mst_ar_data_i,
+  input  logic [iomsb(Cfg.AxiExtNumMst):0][       LogDepth:0] axi_ext_mst_ar_wptr_i,
+  output logic [iomsb(Cfg.AxiExtNumMst):0][       LogDepth:0] axi_ext_mst_ar_rptr_o,
+  input  logic [iomsb(Cfg.AxiExtNumMst):0][ExtMstAwWidth-1:0] axi_ext_mst_aw_data_i,
+  input  logic [iomsb(Cfg.AxiExtNumMst):0][       LogDepth:0] axi_ext_mst_aw_wptr_i,
+  output logic [iomsb(Cfg.AxiExtNumMst):0][       LogDepth:0] axi_ext_mst_aw_rptr_o,
+  output logic [iomsb(Cfg.AxiExtNumMst):0][ ExtMstBWidth-1:0] axi_ext_mst_b_data_o ,
+  output logic [iomsb(Cfg.AxiExtNumMst):0][       LogDepth:0] axi_ext_mst_b_wptr_o ,
+  input  logic [iomsb(Cfg.AxiExtNumMst):0][       LogDepth:0] axi_ext_mst_b_rptr_i ,
+  output logic [iomsb(Cfg.AxiExtNumMst):0][ ExtMstRWidth-1:0] axi_ext_mst_r_data_o ,
+  output logic [iomsb(Cfg.AxiExtNumMst):0][       LogDepth:0] axi_ext_mst_r_wptr_o ,
+  input  logic [iomsb(Cfg.AxiExtNumMst):0][       LogDepth:0] axi_ext_mst_r_rptr_i ,
+  input  logic [iomsb(Cfg.AxiExtNumMst):0][ ExtMstWWidth-1:0] axi_ext_mst_w_data_i ,
+  input  logic [iomsb(Cfg.AxiExtNumMst):0][       LogDepth:0] axi_ext_mst_w_wptr_i ,
+  output logic [iomsb(Cfg.AxiExtNumMst):0][       LogDepth:0] axi_ext_mst_w_rptr_o ,
   // Mailboxes
   output cheshire_axi_ext_slv_req_t axi_mbox_slv_req_o,
   input  cheshire_axi_ext_slv_rsp_t axi_mbox_slv_rsp_i,
@@ -506,7 +418,7 @@ for (genvar i = 0; i < NumSlaveCDCs; i++) begin: gen_ext_slv_src_cdc
 end
 
 // Cheshire's AXI slave cdc and isolate generation, except for the Integer Cluster (slave 7)
-for (genvar i = 0; i < NumMasterCDCs; i++) begin: gen_ext_mst_dst_cdc
+for (genvar i = 0; i < Cfg.AxiExtNumMst; i++) begin: gen_ext_mst_dst_cdc
   axi_cdc_dst #(
     .LogDepth   ( LogDepth                   ),
     .SyncStages ( CdcSyncStages              ),
@@ -597,158 +509,6 @@ axi_cdc_src #(
   .async_data_master_r_wptr_i  ( llc_mst_r_wptr_i  ),
   .async_data_master_r_rptr_o  ( llc_mst_r_rptr_o  )
 );
-
-if (CarfieldIslandsCfg.pulp) begin : gen_pulp_cluster
-  // Integer Cluster slave bus
-  axi_intcluster_slv_req_t axi_intcluster_ser_slv_req, axi_intcluster_ser_isolated_slv_req;
-  axi_intcluster_slv_rsp_t axi_intcluster_ser_slv_rsp, axi_intcluster_ser_isolated_slv_rsp;
-
-  axi_id_remap            #(
-    .AxiSlvPortIdWidth     ( ExtSlvIdWidth              ),
-    .AxiSlvPortMaxUniqIds  ( IntClusterMaxUniqId        ),
-    .AxiMaxTxnsPerId       ( Cfg.AxiMaxSlvTrans         ),
-    .AxiMstPortIdWidth     ( IntClusterAxiIdInWidth     ),
-    .slv_req_t             ( cheshire_axi_ext_slv_req_t ),
-    .slv_resp_t            ( cheshire_axi_ext_slv_rsp_t ),
-    .mst_req_t             ( axi_intcluster_slv_req_t   ),
-    .mst_resp_t            ( axi_intcluster_slv_rsp_t   )
-  ) i_integer_cluster_axi_slv_id_remap               (
-    .clk_i       ( clk_i                             ),
-    .rst_ni      ( rst_ni                            ),
-    .slv_req_i   ( axi_ext_slv_req[IntClusterSlvIdx] ),
-    .slv_resp_o  ( axi_ext_slv_rsp[IntClusterSlvIdx] ),
-    .mst_req_o   ( axi_intcluster_ser_slv_req        ),
-    .mst_resp_i  ( axi_intcluster_ser_slv_rsp        )
-  );
-
-  axi_isolate               #(
-    .NumPending              ( Cfg.AxiMaxSlvTrans       ),
-    .TerminateTransaction    ( 1                        ),
-    .AtopSupport             ( 1                        ),
-    .AxiAddrWidth            ( Cfg.AddrWidth            ),
-    .AxiDataWidth            ( Cfg.AxiDataWidth         ),
-    .AxiIdWidth              ( IntClusterAxiIdInWidth   ),
-    .AxiUserWidth            ( Cfg.AxiUserWidth         ),
-    .axi_req_t               ( axi_intcluster_slv_req_t ),
-    .axi_resp_t              ( axi_intcluster_slv_rsp_t )
-  ) i_axi_intcluster_isolate (
-    .clk_i                   ( clk_i                                    ),
-    .rst_ni                  ( rst_ni                                   ),
-    .slv_req_i               ( axi_intcluster_ser_slv_req               ),
-    .slv_resp_o              ( axi_intcluster_ser_slv_rsp               ),
-    .mst_req_o               ( axi_intcluster_ser_isolated_slv_req      ),
-    .mst_resp_i              ( axi_intcluster_ser_isolated_slv_rsp      ),
-    .isolate_i               ( axi_ext_slv_isolate_i [IntClusterSlvIdx] ),
-    .isolated_o              ( axi_ext_slv_isolated_o[IntClusterSlvIdx] )
-  );
-
-  axi_cdc_src  #(
-    .LogDepth   ( LogDepth                     ),
-    .SyncStages ( CdcSyncStages                ),
-    .aw_chan_t  ( axi_intcluster_slv_aw_chan_t ),
-    .w_chan_t   ( axi_intcluster_slv_w_chan_t  ),
-    .b_chan_t   ( axi_intcluster_slv_b_chan_t  ),
-    .ar_chan_t  ( axi_intcluster_slv_ar_chan_t ),
-    .r_chan_t   ( axi_intcluster_slv_r_chan_t  ),
-    .axi_req_t  ( axi_intcluster_slv_req_t     ),
-    .axi_resp_t ( axi_intcluster_slv_rsp_t     )
-  ) i_intcluster_slv_cdc         (
-    // synchronous slave port
-    .src_clk_i                   ( clk_i                               ),
-    .src_rst_ni                  ( rst_ni                              ),
-    .src_req_i                   ( axi_intcluster_ser_isolated_slv_req ),
-    .src_resp_o                  ( axi_intcluster_ser_isolated_slv_rsp ),
-    // asynchronous master port
-    .async_data_master_aw_data_o ( axi_slv_intcluster_aw_data_o ),
-    .async_data_master_aw_wptr_o ( axi_slv_intcluster_aw_wptr_o ),
-    .async_data_master_aw_rptr_i ( axi_slv_intcluster_aw_rptr_i ),
-    .async_data_master_w_data_o  ( axi_slv_intcluster_w_data_o  ),
-    .async_data_master_w_wptr_o  ( axi_slv_intcluster_w_wptr_o  ),
-    .async_data_master_w_rptr_i  ( axi_slv_intcluster_w_rptr_i  ),
-    .async_data_master_b_data_i  ( axi_slv_intcluster_b_data_i  ),
-    .async_data_master_b_wptr_i  ( axi_slv_intcluster_b_wptr_i  ),
-    .async_data_master_b_rptr_o  ( axi_slv_intcluster_b_rptr_o  ),
-    .async_data_master_ar_data_o ( axi_slv_intcluster_ar_data_o ),
-    .async_data_master_ar_wptr_o ( axi_slv_intcluster_ar_wptr_o ),
-    .async_data_master_ar_rptr_i ( axi_slv_intcluster_ar_rptr_i ),
-    .async_data_master_r_data_i  ( axi_slv_intcluster_r_data_i  ),
-    .async_data_master_r_wptr_i  ( axi_slv_intcluster_r_wptr_i  ),
-    .async_data_master_r_rptr_o  ( axi_slv_intcluster_r_rptr_o  )
-  );
-
-  // Integer Cluster master bus
-  axi_intcluster_mst_req_t axi_intcluster_ser_mst_req;
-  axi_intcluster_mst_rsp_t axi_intcluster_ser_mst_rsp;
-
-  axi_cdc_dst #(
-    .LogDepth   ( LogDepth                     ),
-    .SyncStages ( CdcSyncStages                ),
-    .aw_chan_t  ( axi_intcluster_mst_aw_chan_t ),
-    .w_chan_t   ( axi_intcluster_mst_w_chan_t  ),
-    .b_chan_t   ( axi_intcluster_mst_b_chan_t  ),
-    .ar_chan_t  ( axi_intcluster_mst_ar_chan_t ),
-    .r_chan_t   ( axi_intcluster_mst_r_chan_t  ),
-    .axi_req_t  ( axi_intcluster_mst_req_t     ),
-    .axi_resp_t ( axi_intcluster_mst_rsp_t     )
-  ) i_intcluster_mst_cdc        (
-    // asynchronous slave port
-    .async_data_slave_aw_data_i ( axi_mst_intcluster_aw_data_i ),
-    .async_data_slave_aw_wptr_i ( axi_mst_intcluster_aw_wptr_i ),
-    .async_data_slave_aw_rptr_o ( axi_mst_intcluster_aw_rptr_o ),
-    .async_data_slave_w_data_i  ( axi_mst_intcluster_w_data_i  ),
-    .async_data_slave_w_wptr_i  ( axi_mst_intcluster_w_wptr_i  ),
-    .async_data_slave_w_rptr_o  ( axi_mst_intcluster_w_rptr_o  ),
-    .async_data_slave_b_data_o  ( axi_mst_intcluster_b_data_o  ),
-    .async_data_slave_b_wptr_o  ( axi_mst_intcluster_b_wptr_o  ),
-    .async_data_slave_b_rptr_i  ( axi_mst_intcluster_b_rptr_i  ),
-    .async_data_slave_ar_data_i ( axi_mst_intcluster_ar_data_i ),
-    .async_data_slave_ar_wptr_i ( axi_mst_intcluster_ar_wptr_i ),
-    .async_data_slave_ar_rptr_o ( axi_mst_intcluster_ar_rptr_o ),
-    .async_data_slave_r_data_o  ( axi_mst_intcluster_r_data_o  ),
-    .async_data_slave_r_wptr_o  ( axi_mst_intcluster_r_wptr_o  ),
-    .async_data_slave_r_rptr_i  ( axi_mst_intcluster_r_rptr_i  ),
-    // synchronous master port
-    .dst_clk_i  ( clk_i                      ),
-    .dst_rst_ni ( rst_ni                     ),
-    .dst_req_o  ( axi_intcluster_ser_mst_req ),
-    .dst_resp_i ( axi_intcluster_ser_mst_rsp )
-  );
-
-  axi_id_remap            #(
-    .AxiSlvPortIdWidth     ( IntClusterAxiIdOutWidth    ),
-    .AxiSlvPortMaxUniqIds  ( IntClusterMaxUniqId        ),
-    .AxiMaxTxnsPerId       ( Cfg.AxiMaxMstTrans         ),
-    .AxiMstPortIdWidth     ( Cfg.AxiMstIdWidth          ),
-    .slv_req_t             ( axi_intcluster_mst_req_t   ),
-    .slv_resp_t            ( axi_intcluster_mst_rsp_t   ),
-    .mst_req_t             ( cheshire_axi_ext_mst_req_t ),
-    .mst_resp_t            ( cheshire_axi_ext_mst_rsp_t )
-  ) i_integer_cluster_axi_mst_id_remap               (
-    .clk_i       ( clk_i                             ),
-    .rst_ni      ( rst_ni                            ),
-    .slv_req_i   ( axi_intcluster_ser_mst_req        ),
-    .slv_resp_o  ( axi_intcluster_ser_mst_rsp        ),
-    .mst_req_o   ( axi_ext_mst_req[IntClusterMstIdx] ),
-    .mst_resp_i  ( axi_ext_mst_rsp[IntClusterMstIdx] )
-  );
-end else begin: gen_no_pulp_cluster
-  assign axi_slv_intcluster_aw_data_o = '0;
-  assign axi_slv_intcluster_aw_wptr_o = '0;
-  assign axi_slv_intcluster_w_data_o  = '0;
-  assign axi_slv_intcluster_w_wptr_o  = '0;
-  assign axi_slv_intcluster_b_rptr_o  = '0;
-  assign axi_slv_intcluster_ar_data_o = '0;
-  assign axi_slv_intcluster_ar_wptr_o = '0;
-  assign axi_slv_intcluster_r_rptr_o  = '0;
-
-  assign axi_mst_intcluster_aw_rptr_o = '0;
-  assign axi_mst_intcluster_w_rptr_o  = '0;
-  assign axi_mst_intcluster_b_data_o  = '0;
-  assign axi_mst_intcluster_b_wptr_o  = '0;
-  assign axi_mst_intcluster_ar_rptr_o = '0;
-  assign axi_mst_intcluster_r_data_o  = '0;
-  assign axi_mst_intcluster_r_wptr_o  = '0;
-end
 
 // Async reg interface:
 // See carfield_pkg.sv for indices referring to sync and async reg interfaces.


### PR DESCRIPTION
Move AXI ID remappers into PULP cluster to simplify system integration.
Waiting on [#58](https://github.com/pulp-platform/pulp_cluster/pull/58) before merging.
To be backported into Carfield.