### PR TITLE
Extend parametrization to compiled software and initialized hardware.

### DIFF
--- a/Bender.local
+++ b/Bender.local
@@ -14,7 +14,7 @@ overrides:
   hier-icache:          { git: "https://github.com/pulp-platform/hier-icache.git"         , rev: 2886cb2a46cea3e2bd2d979b505d88fadfbe150c   } # branch: astral
   scm:                  { git: "https://github.com/pulp-platform/scm.git"                 , rev: 74426dee36f28ae1c02f7635cf844a0156145320   }
   cluster_interconnect: { git: "https://github.com/pulp-platform/cluster_interconnect.git", rev: 89e1019d64a86425211be6200770576cbdf3e8b3   } # branch: assertion-fix
-  clic:                 { git: "https://github.com/pulp-platform/clic.git"                , rev: 0ff9f07e0a492bff046dfe24399b1e1e82d557b7   } # branch: balasr/dev-2
+  clic:                 { git: "https://github.com/pulp-platform/clic.git"                , rev: 40ae266dab5768f63ca8dabe70e7474feb403bab   } # branch: critical-path
   fpnew:                { git: "https://github.com/pulp-platform/cvfpu.git"               , rev: pulp-v0.1.3 }
   cv32e40p:             { git: "https://github.com/pulp-platform/cv32e40p.git"            , rev: e863f576699815b38cc9d80dbdede8ed5efd5991   }
   axi_rt:               { git: "https://github.com/pulp-platform/axi_rt.git"              , version: =0.0.0-alpha.4                         }

--- a/Bender.local
+++ b/Bender.local
@@ -7,7 +7,7 @@ overrides:
   axi_riscv_atomics:    { git: https://github.com/pulp-platform/axi_riscv_atomics.git     , version: 0.8.2 }
   apb:                  { git: "https://github.com/pulp-platform/apb.git"                 , version: 0.2.3 }
   redundancy_cells:     { git: "https://github.com/pulp-platform/redundancy_cells.git"    , rev: "c37bdb47339bf70e8323de8df14ea8bbeafb6583" } # branch: astral-rebase
-  hci:                  { git: "https://github.com/pulp-platform/hci.git"                 , rev: v1.1 }
+  hci:                  { git: "https://github.com/pulp-platform/hci.git"                 , rev: e47627c20b33bcaf4842c1add81fb888b4f12a9d   } # branch: old commit in v2.0.0
   tech_cells_generic:   { git: "https://github.com/pulp-platform/tech_cells_generic.git"  , version: =0.2.13                                }
   riscv-dbg:            { git: "https://github.com/pulp-platform/riscv-dbg.git"           , version: =0.8.0                                 }
   idma:                 { git: "https://github.com/pulp-platform/idma.git"                , version: 0.5.1                                  }

--- a/Bender.lock
+++ b/Bender.lock
@@ -106,7 +106,7 @@ packages:
       Git: https://github.com/AlSaqr-platform/can_bus.git
     dependencies: []
   cheshire:
-    revision: 6d389373df6b54c09888f89411b7e231d2430722
+    revision: b2372f9f38b38f990941204b3fa3cee93056e2a9
     version: null
     source:
       Git: https://github.com/pulp-platform/cheshire.git

--- a/Bender.lock
+++ b/Bender.lock
@@ -106,7 +106,7 @@ packages:
       Git: https://github.com/AlSaqr-platform/can_bus.git
     dependencies: []
   cheshire:
-    revision: b2372f9f38b38f990941204b3fa3cee93056e2a9
+    revision: cc1ca617df246f7aae7ef76d5a3277e44b974ed6
     version: null
     source:
       Git: https://github.com/pulp-platform/cheshire.git

--- a/Bender.lock
+++ b/Bender.lock
@@ -132,8 +132,8 @@ packages:
     - tagger
     - unbent
   clic:
-    revision: 0ff9f07e0a492bff046dfe24399b1e1e82d557b7
-    version: 3.0.0-for-carfield
+    revision: 40ae266dab5768f63ca8dabe70e7474feb403bab
+    version: null
     source:
       Git: https://github.com/pulp-platform/clic.git
     dependencies:

--- a/Bender.lock
+++ b/Bender.lock
@@ -338,7 +338,7 @@ packages:
     - common_cells
     - common_verification
   opentitan:
-    revision: c3d6967775e80c5a2cb8086e2618d1a829464bc5
+    revision: 3fc11c14f29a161054766fabd95f90ab2a9e473a
     version: null
     source:
       Git: https://github.com/pulp-platform/opentitan.git

--- a/Bender.lock
+++ b/Bender.lock
@@ -344,6 +344,9 @@ packages:
       Git: https://github.com/pulp-platform/opentitan.git
     dependencies:
     - axi
+    - cluster_interconnect
+    - idma
+    - register_interface
   opentitan_peripherals:
     revision: cd3153de2783abd3d03d0595e6c4b32413c62f14
     version: 0.4.0

--- a/Bender.lock
+++ b/Bender.lock
@@ -231,7 +231,7 @@ packages:
     dependencies:
     - common_cells
   hci:
-    revision: 4823e503851eb7e8cc765a58621d767a01d6a77b
+    revision: e47627c20b33bcaf4842c1add81fb888b4f12a9d
     version: null
     source:
       Git: https://github.com/pulp-platform/hci.git

--- a/Bender.lock
+++ b/Bender.lock
@@ -155,15 +155,15 @@ packages:
     dependencies:
     - common_cells
   cluster_peripherals:
-    revision: c9defcfb4f4e8733383b28a451c430783c2febbd
+    revision: 8a9f62dafb5ec23c6cd361847ff0047e12befca4
     version: null
     source:
       Git: https://github.com/pulp-platform/cluster_peripherals.git
     dependencies:
     - hci
   common_cells:
-    revision: ad22699793d98ef714f120c6268fe92d096a61e1
-    version: 1.33.1
+    revision: 7773d971b9d7bef7f5f6a2ef36ee1e4d02cefcd3
+    version: 1.34.0
     source:
       Git: https://github.com/pulp-platform/common_cells.git
     dependencies:
@@ -252,15 +252,15 @@ packages:
     - scm
     - tech_cells_generic
   hwpe-ctrl:
-    revision: b7857919ea14b586901ff4282ad7749a3d50501e
+    revision: a5966201aeeb988d607accdc55da933a53c6a56e
     version: null
     source:
       Git: https://github.com/pulp-platform/hwpe-ctrl.git
     dependencies:
     - tech_cells_generic
   hwpe-stream:
-    revision: bcb4435f802add732f557dc7fa1c6b5dd8854458
-    version: 1.7.1
+    revision: 65c99a4a2f37a79acee800ab0151f67dfb1edef1
+    version: 1.8.0
     source:
       Git: https://github.com/pulp-platform/hwpe-stream.git
     dependencies:
@@ -329,6 +329,16 @@ packages:
       Git: https://github.com/pulp-platform/mchan.git
     dependencies:
     - common_cells
+  neureka:
+    revision: 3131e87c40118f75e11a1ff9bae60fe764336a19
+    version: null
+    source:
+      Git: https://github.com/pulp-platform/neureka.git
+    dependencies:
+    - hci
+    - hwpe-ctrl
+    - hwpe-stream
+    - zeroriscy
   obi:
     revision: 1aa411df145c4ebdd61f8fed4d003c33f7b20636
     version: 0.1.2
@@ -372,7 +382,7 @@ packages:
     - axi
     - common_verification
   pulp_cluster:
-    revision: 7a3141a804cd0df60cb039764547daa7c075852b
+    revision: 9be39b5b300f48015c931993273f9a288abc1318
     version: null
     source:
       Git: https://github.com/pulp-platform/pulp_cluster.git
@@ -390,6 +400,7 @@ packages:
     - ibex
     - idma
     - mchan
+    - neureka
     - per2axi
     - redmule
     - redundancy_cells
@@ -399,7 +410,7 @@ packages:
     - tech_cells_generic
     - timer_unit
   redmule:
-    revision: 1b30b0b9a31afa702eb2d166d672ceda2f5d463a
+    revision: 68999ccc922b10a5043bb98f67aaf3d8d8d59f3f
     version: null
     source:
       Git: https://github.com/pulp-platform/redmule.git
@@ -531,3 +542,9 @@ packages:
     - axi
     - common_cells
     - register_interface
+  zeroriscy:
+    revision: 8a6c00e899cb6c715dcd5a3a1a92263994fb634b
+    version: null
+    source:
+      Git: git@github.com:yvantor/ibex.git
+    dependencies: []

--- a/Bender.lock
+++ b/Bender.lock
@@ -372,7 +372,7 @@ packages:
     - axi
     - common_verification
   pulp_cluster:
-    revision: 3cd3e83fdd7a791e8ae54aef39423004581c8a48
+    revision: 7a3141a804cd0df60cb039764547daa7c075852b
     version: null
     source:
       Git: https://github.com/pulp-platform/pulp_cluster.git

--- a/Bender.lock
+++ b/Bender.lock
@@ -543,7 +543,7 @@ packages:
     - common_cells
     - register_interface
   zeroriscy:
-    revision: 8a6c00e899cb6c715dcd5a3a1a92263994fb634b
+    revision: cc4068a0ccb7691cd062b809c34b2304e7fbfa36
     version: null
     source:
       Git: git@github.com:yvantor/ibex.git

--- a/Bender.lock
+++ b/Bender.lock
@@ -338,7 +338,7 @@ packages:
     - common_cells
     - common_verification
   opentitan:
-    revision: 6a9fd5544933f9aea3469f4d1ed612844aab1982
+    revision: c3d6967775e80c5a2cb8086e2618d1a829464bc5
     version: null
     source:
       Git: https://github.com/pulp-platform/opentitan.git

--- a/Bender.lock
+++ b/Bender.lock
@@ -338,7 +338,7 @@ packages:
     - common_cells
     - common_verification
   opentitan:
-    revision: 74e7d6ca17e6a46e727ae2ae11177611232eaeb9
+    revision: 6a9fd5544933f9aea3469f4d1ed612844aab1982
     version: null
     source:
       Git: https://github.com/pulp-platform/opentitan.git

--- a/Bender.yml
+++ b/Bender.yml
@@ -13,7 +13,7 @@ package:
 dependencies:
   register_interface: { git: https://github.com/pulp-platform/register_interface.git,   version: 0.4.3                                }
   axi:                { git: https://github.com/pulp-platform/axi.git,                  version: 0.39.1                               }
-  cheshire:           { git: https://github.com/pulp-platform/cheshire.git,             rev: b2372f9f38b38f990941204b3fa3cee93056e2a9 } # branch: astral-new
+  cheshire:           { git: https://github.com/pulp-platform/cheshire.git,             rev: cc1ca617df246f7aae7ef76d5a3277e44b974ed6 } # branch: buildroot-remote
   hyperbus:           { git: https://github.com/pulp-platform/hyperbus.git,             rev: f039e601c8b6590181734e6d26ff8b77aa380412 } # branch: chi/add_fsm_with_Tcsh
   dyn_mem:            { git: https://github.com/pulp-platform/dyn_spm.git,              rev: 480590062742230dc9bd4050358a15b4747bdf34 } # branch: main
   safety_island:      { git: https://github.com/pulp-platform/safety_island.git,        rev: aaef55c798ab53560faaf451a86668fa1e6d0f3b } # branch: carfield

--- a/Bender.yml
+++ b/Bender.yml
@@ -13,7 +13,7 @@ package:
 dependencies:
   register_interface: { git: https://github.com/pulp-platform/register_interface.git,   version: 0.4.3                                }
   axi:                { git: https://github.com/pulp-platform/axi.git,                  version: 0.39.1                               }
-  cheshire:           { git: https://github.com/pulp-platform/cheshire.git,             rev: 6d389373df6b54c09888f89411b7e231d2430722 } # branch: astral-new
+  cheshire:           { git: https://github.com/pulp-platform/cheshire.git,             rev: b2372f9f38b38f990941204b3fa3cee93056e2a9 } # branch: astral-new
   hyperbus:           { git: https://github.com/pulp-platform/hyperbus.git,             rev: f039e601c8b6590181734e6d26ff8b77aa380412 } # branch: chi/add_fsm_with_Tcsh
   dyn_mem:            { git: https://github.com/pulp-platform/dyn_spm.git,              rev: 480590062742230dc9bd4050358a15b4747bdf34 } # branch: main
   safety_island:      { git: https://github.com/pulp-platform/safety_island.git,        rev: aaef55c798ab53560faaf451a86668fa1e6d0f3b } # branch: carfield

--- a/Bender.yml
+++ b/Bender.yml
@@ -76,6 +76,10 @@ sources:
     files:
       - hw/configs/carfield_l2dual_safe_pulp_spatz_periph.sv
 
+  - target: carfield_l2dual_secure_pulp_periph_can
+    files:
+      - hw/configs/carfield_l2dual_secure_pulp_periph_can.sv
+
   # Source files grouped in levels. Files in level 0 have no dependencies on files in this
   # package. Files in level 1 only depend on files in level 0, files in level 2 on files in
   # levels 1 and 0, etc. Files within a level are ordered alphabetically.

--- a/Bender.yml
+++ b/Bender.yml
@@ -111,7 +111,7 @@ sources:
     files:
       - tech/sourcecode/tc_clk.sv
       - tech/sourcecode/tc_sram.sv
-      - target/synth/carfield_synth_wrap.sv
+      - target/synth/src/carfield_synth_wrap.sv
 
   - target: tech_sim
     files:

--- a/Bender.yml
+++ b/Bender.yml
@@ -18,7 +18,7 @@ dependencies:
   dyn_mem:            { git: https://github.com/pulp-platform/dyn_spm.git,              rev: 480590062742230dc9bd4050358a15b4747bdf34 } # branch: main
   safety_island:      { git: https://github.com/pulp-platform/safety_island.git,        rev: aaef55c798ab53560faaf451a86668fa1e6d0f3b } # branch: carfield
   pulp_cluster:       { git: https://github.com/pulp-platform/pulp_cluster.git,         rev: 3cd3e83fdd7a791e8ae54aef39423004581c8a48 } # branch: astral
-  opentitan:          { git: https://github.com/pulp-platform/opentitan.git,            rev: 6a9fd5544933f9aea3469f4d1ed612844aab1982 } # branch: mc/astral
+  opentitan:          { git: https://github.com/pulp-platform/opentitan.git,            rev: c3d6967775e80c5a2cb8086e2618d1a829464bc5 } # branch: mc/astral
   mailbox_unit:       { git: https://github.com/pulp-platform/mailbox_unit.git,         version: 1.1.0                                }
   apb:                { git: https://github.com/pulp-platform/apb.git,                  version: 0.2.3                                }
   timer_unit:         { git: https://github.com/pulp-platform/timer_unit.git,           version: 1.0.2                                }

--- a/Bender.yml
+++ b/Bender.yml
@@ -18,7 +18,7 @@ dependencies:
   dyn_mem:            { git: https://github.com/pulp-platform/dyn_spm.git,              rev: 480590062742230dc9bd4050358a15b4747bdf34 } # branch: main
   safety_island:      { git: https://github.com/pulp-platform/safety_island.git,        rev: aaef55c798ab53560faaf451a86668fa1e6d0f3b } # branch: carfield
   pulp_cluster:       { git: https://github.com/pulp-platform/pulp_cluster.git,         rev: 3cd3e83fdd7a791e8ae54aef39423004581c8a48 } # branch: astral
-  opentitan:          { git: https://github.com/pulp-platform/opentitan.git,            rev: c3d6967775e80c5a2cb8086e2618d1a829464bc5 } # branch: mc/astral
+  opentitan:          { git: https://github.com/pulp-platform/opentitan.git,            rev: 3fc11c14f29a161054766fabd95f90ab2a9e473a } # branch: mc/astral
   mailbox_unit:       { git: https://github.com/pulp-platform/mailbox_unit.git,         version: 1.1.0                                }
   apb:                { git: https://github.com/pulp-platform/apb.git,                  version: 0.2.3                                }
   timer_unit:         { git: https://github.com/pulp-platform/timer_unit.git,           version: 1.0.2                                }

--- a/Bender.yml
+++ b/Bender.yml
@@ -17,7 +17,7 @@ dependencies:
   hyperbus:           { git: https://github.com/pulp-platform/hyperbus.git,             rev: f039e601c8b6590181734e6d26ff8b77aa380412 } # branch: chi/add_fsm_with_Tcsh
   dyn_mem:            { git: https://github.com/pulp-platform/dyn_spm.git,              rev: 480590062742230dc9bd4050358a15b4747bdf34 } # branch: main
   safety_island:      { git: https://github.com/pulp-platform/safety_island.git,        rev: aaef55c798ab53560faaf451a86668fa1e6d0f3b } # branch: carfield
-  pulp_cluster:       { git: https://github.com/pulp-platform/pulp_cluster.git,         rev: 7a3141a804cd0df60cb039764547daa7c075852b } # branch: astral
+  pulp_cluster:       { git: https://github.com/pulp-platform/pulp_cluster.git,         rev: 9be39b5b300f48015c931993273f9a288abc1318 } # branch: astral
   opentitan:          { git: https://github.com/pulp-platform/opentitan.git,            rev: 3fc11c14f29a161054766fabd95f90ab2a9e473a } # branch: mc/astral
   mailbox_unit:       { git: https://github.com/pulp-platform/mailbox_unit.git,         version: 1.1.0                                }
   apb:                { git: https://github.com/pulp-platform/apb.git,                  version: 0.2.3                                }

--- a/Bender.yml
+++ b/Bender.yml
@@ -39,6 +39,11 @@ workspace:
 
 sources:
   # Configurations
+    # "Small" Astral configuration
+  - target: carfield_secure_pulp_periph_can
+    files:
+      - hw/configs/carfield_secure_pulp_periph_can.sv
+
   - target: carfield_l2dual_safe_secure_pulp_spatz_periph_can
     files:
       - hw/configs/carfield_l2dual_safe_secure_pulp_spatz_periph_can.sv

--- a/Bender.yml
+++ b/Bender.yml
@@ -17,8 +17,8 @@ dependencies:
   hyperbus:           { git: https://github.com/pulp-platform/hyperbus.git,             rev: f039e601c8b6590181734e6d26ff8b77aa380412 } # branch: chi/add_fsm_with_Tcsh
   dyn_mem:            { git: https://github.com/pulp-platform/dyn_spm.git,              rev: 480590062742230dc9bd4050358a15b4747bdf34 } # branch: main
   safety_island:      { git: https://github.com/pulp-platform/safety_island.git,        rev: aaef55c798ab53560faaf451a86668fa1e6d0f3b } # branch: carfield
-  pulp_cluster:       { git: https://github.com/pulp-platform/pulp_cluster.git,         rev: 3cd3e83fdd7a791e8ae54aef39423004581c8a48 } # branch: idw-conv
-  opentitan:          { git: https://github.com/pulp-platform/opentitan.git,            rev: 74e7d6ca17e6a46e727ae2ae11177611232eaeb9 } # branch: carfield_soc
+  pulp_cluster:       { git: https://github.com/pulp-platform/pulp_cluster.git,         rev: 3cd3e83fdd7a791e8ae54aef39423004581c8a48 } # branch: astral
+  opentitan:          { git: https://github.com/pulp-platform/opentitan.git,            rev: 6a9fd5544933f9aea3469f4d1ed612844aab1982 } # branch: mc/astral
   mailbox_unit:       { git: https://github.com/pulp-platform/mailbox_unit.git,         version: 1.1.0                                }
   apb:                { git: https://github.com/pulp-platform/apb.git,                  version: 0.2.3                                }
   timer_unit:         { git: https://github.com/pulp-platform/timer_unit.git,           version: 1.0.2                                }

--- a/Bender.yml
+++ b/Bender.yml
@@ -17,7 +17,7 @@ dependencies:
   hyperbus:           { git: https://github.com/pulp-platform/hyperbus.git,             rev: f039e601c8b6590181734e6d26ff8b77aa380412 } # branch: chi/add_fsm_with_Tcsh
   dyn_mem:            { git: https://github.com/pulp-platform/dyn_spm.git,              rev: 480590062742230dc9bd4050358a15b4747bdf34 } # branch: main
   safety_island:      { git: https://github.com/pulp-platform/safety_island.git,        rev: aaef55c798ab53560faaf451a86668fa1e6d0f3b } # branch: carfield
-  pulp_cluster:       { git: https://github.com/pulp-platform/pulp_cluster.git,         rev: 3cd3e83fdd7a791e8ae54aef39423004581c8a48 } # branch: astral
+  pulp_cluster:       { git: https://github.com/pulp-platform/pulp_cluster.git,         rev: 7a3141a804cd0df60cb039764547daa7c075852b } # branch: astral
   opentitan:          { git: https://github.com/pulp-platform/opentitan.git,            rev: 3fc11c14f29a161054766fabd95f90ab2a9e473a } # branch: mc/astral
   mailbox_unit:       { git: https://github.com/pulp-platform/mailbox_unit.git,         version: 1.1.0                                }
   apb:                { git: https://github.com/pulp-platform/apb.git,                  version: 0.2.3                                }

--- a/bender-common.mk
+++ b/bender-common.mk
@@ -6,7 +6,7 @@
 # Author: Matteo Perotti <mperotti@iis.ee.ethz.ch>
 
 # Runtime-selectable Carfield configuration
-CARFIELD_CONFIG ?= carfield_l2dual_secure_pulp_periph_can
+CARFIELD_CONFIG ?= carfield_l2dual_safe_secure_pulp_spatz_periph_can
 
 # bender targets
 common_targs += -t cva6

--- a/bender-common.mk
+++ b/bender-common.mk
@@ -6,7 +6,7 @@
 # Author: Matteo Perotti <mperotti@iis.ee.ethz.ch>
 
 # Runtime-selectable Carfield configuration
-CARFIELD_CONFIG ?= carfield_secure_pulp_periph_can
+CARFIELD_CONFIG ?= carfield_l2dual_secure_pulp_periph_can
 
 # bender targets
 common_targs += -t cva6

--- a/bender-common.mk
+++ b/bender-common.mk
@@ -6,7 +6,7 @@
 # Author: Matteo Perotti <mperotti@iis.ee.ethz.ch>
 
 # Runtime-selectable Carfield configuration
-CARFIELD_CONFIG ?= carfield_l2dual_safe_secure_pulp_spatz_periph_can
+CARFIELD_CONFIG ?= carfield_secure_pulp_periph_can
 
 # bender targets
 common_targs += -t cva6

--- a/carfield.mk
+++ b/carfield.mk
@@ -157,6 +157,10 @@ car-checkout: car-checkout-deps
 # Build SW #
 ############
 include $(CAR_SW_DIR)/sw.mk
+ifeq ($(shell echo $(PULPD_PRESENT)), 1)
+PULPD_SW_BUILD := pulpd-sw-build
+PULPD_SW_INIT := pulpd-sw-init
+endif
 
 ## @section Carfield platform SW build
 .PHONY: chs-sw-build
@@ -166,7 +170,7 @@ chs-sw-build: chs-sw-all
 
 .PHONY: car-sw-build
 ## Builds carfield application SW and specific libraries. It links against `libcheshire.a`.
-car-sw-build: chs-sw-build safed-sw-build pulpd-sw-build car-sw-all
+car-sw-build: chs-sw-build safed-sw-build $(PULPD_SW_BUILD) car-sw-all
 
 .PHONY: safed-sw-init pulpd-sw-init
 ## Clone safe domain's SW stack in the dedicated repository.
@@ -289,7 +293,7 @@ include $(CAR_SIM_DIR)/sim.mk
 
 .PHONY: car-init-all
 ## Shortcut to initialize carfield with all the targets described above.
-car-init-all: car-checkout car-hw-init car-sim-init safed-sw-init pulpd-sw-init mibench
+car-init-all: car-checkout car-hw-init car-sim-init safed-sw-init $(PULPD_SW_INIT) mibench
 
 ## Initialize Carfield and build SW
 .PHONY: car-all

--- a/carfield.mk
+++ b/carfield.mk
@@ -347,7 +347,7 @@ include $(CAR_XIL_DIR)/xilinx.mk
 mibench: $(CAR_SW_DIR)/benchmarks/mibench
 
 $(CAR_SW_DIR)/benchmarks/mibench:
-	git clone git@github.com:alex96295/mibench.git -b carfield $@
+	git clone https://github.com/alex96295/mibench.git -b carfield $@
 
 # Litmus tests
 LITMUS_WORK_DIR  := work-litmus

--- a/carfield.mk
+++ b/carfield.mk
@@ -156,13 +156,27 @@ car-checkout: car-checkout-deps
 ############
 # Build SW #
 ############
-include $(CAR_SW_DIR)/sw.mk
+## @section Islands compile exclusion
 ifeq ($(shell echo $(PULPD_PRESENT)), 1)
 PULPD_SW_BUILD := pulpd-sw-build
 PULPD_SW_INIT := pulpd-sw-init
 endif
 
+ifeq ($(shell echo $(SAFED_PRESENT)), 1)
+SAFED_SW_BUILD := safed-sw-build
+SAFED_SW_INIT := safed-sw-init
+endif
+
+ifeq ($(shell echo $(SAFED_PRESENT)), 1)
+SPATZD_HW_INIT := spatzd-hw-init
+endif
+
+ifeq ($(shell echo $(SECURED_PRESENT)), 1)
+SECD_HW_INIT := secd-hw-init
+endif
+
 ## @section Carfield platform SW build
+include $(CAR_SW_DIR)/sw.mk
 .PHONY: chs-sw-build
 ## Build the host domain (Cheshire) SW libraries and generates an archive (`libcheshire.a`)
 ## available for Carfield as static library at link time.
@@ -170,7 +184,7 @@ chs-sw-build: chs-sw-all
 
 .PHONY: car-sw-build
 ## Builds carfield application SW and specific libraries. It links against `libcheshire.a`.
-car-sw-build: chs-sw-build safed-sw-build $(PULPD_SW_BUILD) car-sw-all
+car-sw-build: chs-sw-build $(SAFED_SW_BUILD) $(PULPD_SW_BUILD) car-sw-all
 
 .PHONY: safed-sw-init pulpd-sw-init
 ## Clone safe domain's SW stack in the dedicated repository.
@@ -218,7 +232,7 @@ pulpd-sw-build: pulpd-sw-init
 ## Initialize Carfield HW. This step takes care of the generation of the missing hardware or the
 ## update of default HW configurations in some of the domains. See the two prerequisite's comment
 ## for more information.
-car-hw-init: spatzd-hw-init chs-hw-init secd-hw-init
+car-hw-init: $(SPATZD_HW_INIT) chs-hw-init $(SECD_HW_INIT)
 
 #Build OpenTitan's debug rom with support for coreid != 0x0
 secd-hw-init:
@@ -293,7 +307,7 @@ include $(CAR_SIM_DIR)/sim.mk
 
 .PHONY: car-init-all
 ## Shortcut to initialize carfield with all the targets described above.
-car-init-all: car-checkout car-hw-init car-sim-init safed-sw-init $(PULPD_SW_INIT) mibench
+car-init-all: car-checkout car-hw-init car-sim-init $(SAFED_SW_INIT) $(PULPD_SW_INIT) mibench
 
 ## Initialize Carfield and build SW
 .PHONY: car-all

--- a/carfield.mk
+++ b/carfield.mk
@@ -167,7 +167,7 @@ SAFED_SW_BUILD := safed-sw-build
 SAFED_SW_INIT := safed-sw-init
 endif
 
-ifeq ($(shell echo $(SAFED_PRESENT)), 1)
+ifeq ($(shell echo $(SPATZD_PRESENT)), 1)
 SPATZD_HW_INIT := spatzd-hw-init
 endif
 

--- a/carfield.mk
+++ b/carfield.mk
@@ -47,7 +47,7 @@ include $(CAR_ROOT)/bender-safed.mk
 ######################
 
 CAR_NONFREE_REMOTE ?= git@iis-git.ee.ethz.ch:astral/astral-nonfree.git
-CAR_NONFREE_COMMIT ?= a92349785618f9fe6e39d5bc5a47820462886647
+CAR_NONFREE_COMMIT ?= 28fc3580f64f048174cc7dbb618421c254364c74
 
 ## @section Carfield platform nonfree components
 ## Clone the non-free verification IP for Carfield. Some components such as CI scripts and ASIC

--- a/carfield.mk
+++ b/carfield.mk
@@ -23,6 +23,7 @@ CAR_SW_DIR  := $(CAR_ROOT)/sw
 CAR_TGT_DIR := $(CAR_ROOT)/target/
 CAR_XIL_DIR := $(CAR_TGT_DIR)/xilinx
 CAR_SIM_DIR := $(CAR_TGT_DIR)/sim
+SECD_ROOT    ?= $(shell $(BENDER) path opentitan)
 # Questasim
 CAR_VSIM_DIR := $(CAR_TGT_DIR)/sim/vsim
 
@@ -213,7 +214,11 @@ pulpd-sw-build: pulpd-sw-init
 ## Initialize Carfield HW. This step takes care of the generation of the missing hardware or the
 ## update of default HW configurations in some of the domains. See the two prerequisite's comment
 ## for more information.
-car-hw-init: spatzd-hw-init chs-hw-init
+car-hw-init: spatzd-hw-init chs-hw-init secd-hw-init
+
+#Build OpenTitan's debug rom with support for coreid=0x4
+secd-hw-init:
+	$(MAKE) -C $(SECD_ROOT)/hw/vendor/pulp_riscv_dbg/debug_rom clean all FLAGS=-DCARFIELD=1
 
 ## @section Carfield platform PCRs generation
 .PHONY: regenerate_soc_regs

--- a/carfield.mk
+++ b/carfield.mk
@@ -47,7 +47,7 @@ include $(CAR_ROOT)/bender-safed.mk
 ######################
 
 CAR_NONFREE_REMOTE ?= git@iis-git.ee.ethz.ch:astral/astral-nonfree.git
-CAR_NONFREE_COMMIT ?= 711d0097
+CAR_NONFREE_COMMIT ?= 3b5694e683d1f937719652f61ab2b433ad6dc5d0
 
 ## @section Carfield platform nonfree components
 ## Clone the non-free verification IP for Carfield. Some components such as CI scripts and ASIC

--- a/carfield.mk
+++ b/carfield.mk
@@ -47,7 +47,7 @@ include $(CAR_ROOT)/bender-safed.mk
 ######################
 
 CAR_NONFREE_REMOTE ?= git@iis-git.ee.ethz.ch:astral/astral-nonfree.git
-CAR_NONFREE_COMMIT ?= 3b5694e683d1f937719652f61ab2b433ad6dc5d0
+CAR_NONFREE_COMMIT ?= dcb1a4bcb62b087dab1f46bfff265cba324ae23b
 
 ## @section Carfield platform nonfree components
 ## Clone the non-free verification IP for Carfield. Some components such as CI scripts and ASIC

--- a/carfield.mk
+++ b/carfield.mk
@@ -47,7 +47,7 @@ include $(CAR_ROOT)/bender-safed.mk
 ######################
 
 CAR_NONFREE_REMOTE ?= git@iis-git.ee.ethz.ch:astral/astral-nonfree.git
-CAR_NONFREE_COMMIT ?= 925646ff8ebb47e94297295fa0b47f092e26ab39
+CAR_NONFREE_COMMIT ?= a92349785618f9fe6e39d5bc5a47820462886647
 
 ## @section Carfield platform nonfree components
 ## Clone the non-free verification IP for Carfield. Some components such as CI scripts and ASIC

--- a/carfield.mk
+++ b/carfield.mk
@@ -47,7 +47,7 @@ include $(CAR_ROOT)/bender-safed.mk
 ######################
 
 CAR_NONFREE_REMOTE ?= git@iis-git.ee.ethz.ch:astral/astral-nonfree.git
-CAR_NONFREE_COMMIT ?= dcb1a4bcb62b087dab1f46bfff265cba324ae23b
+CAR_NONFREE_COMMIT ?= 925646ff8ebb47e94297295fa0b47f092e26ab39
 
 ## @section Carfield platform nonfree components
 ## Clone the non-free verification IP for Carfield. Some components such as CI scripts and ASIC

--- a/carfield.mk
+++ b/carfield.mk
@@ -23,7 +23,7 @@ CAR_SW_DIR  := $(CAR_ROOT)/sw
 CAR_TGT_DIR := $(CAR_ROOT)/target/
 CAR_XIL_DIR := $(CAR_TGT_DIR)/xilinx
 CAR_SIM_DIR := $(CAR_TGT_DIR)/sim
-SECD_ROOT    ?= $(shell $(BENDER) path opentitan)
+SECD_ROOT ?= $(shell $(BENDER) path opentitan)
 # Questasim
 CAR_VSIM_DIR := $(CAR_TGT_DIR)/sim/vsim
 
@@ -216,7 +216,7 @@ pulpd-sw-build: pulpd-sw-init
 ## for more information.
 car-hw-init: spatzd-hw-init chs-hw-init secd-hw-init
 
-#Build OpenTitan's debug rom with support for coreid=0x4
+#Build OpenTitan's debug rom with support for coreid != 0x0
 secd-hw-init:
 	$(MAKE) -C $(SECD_ROOT)/hw/vendor/pulp_riscv_dbg/debug_rom clean all FLAGS=-DCARFIELD=1
 

--- a/env/env-iis.sh
+++ b/env/env-iis.sh
@@ -3,6 +3,9 @@
 # SPDX-License-Identifier: SHL-0.51
 #
 
+# Set environment variables to choose of which island we have to compile the sw
+export PULPD_PRESENT=1
+
 # set up environment variables for rtl simulation
 ROOTD=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/.." && pwd)
 export PATH=/usr/pack/riscv-1.0-kgf/riscv64-gcc-11.2.0/bin:$PATH # RV64 GCC toolchain

--- a/env/env-iis.sh
+++ b/env/env-iis.sh
@@ -4,9 +4,9 @@
 #
 
 # Set environment variables to choose of which island we have to compile the sw
-export PULPD_PRESENT=0
+export PULPD_PRESENT=1
 export SAFED_PRESENT=0
-export SECURED_PRESENT=0
+export SECURED_PRESENT=1
 export SPATZD_PRESENT=0
 
 # set up environment variables for rtl simulation

--- a/env/env-iis.sh
+++ b/env/env-iis.sh
@@ -5,7 +5,7 @@
 
 # Set environment variables to choose of which island we have to compile the sw
 export PULPD_PRESENT=1
-export SAFED_PRESENT=0
+export SAFED_PRESENT=1
 export SECURED_PRESENT=1
 export SPATZD_PRESENT=1
 

--- a/env/env-iis.sh
+++ b/env/env-iis.sh
@@ -7,7 +7,7 @@
 export PULPD_PRESENT=1
 export SAFED_PRESENT=0
 export SECURED_PRESENT=1
-export SPATZD_PRESENT=0
+export SPATZD_PRESENT=1
 
 # set up environment variables for rtl simulation
 ROOTD=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/.." && pwd)

--- a/env/env-iis.sh
+++ b/env/env-iis.sh
@@ -4,7 +4,10 @@
 #
 
 # Set environment variables to choose of which island we have to compile the sw
-export PULPD_PRESENT=1
+export PULPD_PRESENT=0
+export SAFED_PRESENT=0
+export SECURED_PRESENT=0
+export SPATZD_PRESENT=0
 
 # set up environment variables for rtl simulation
 ROOTD=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/.." && pwd)

--- a/env/pulpd-env.sh
+++ b/env/pulpd-env.sh
@@ -5,4 +5,4 @@
 
 # set up environment variables for rtl simulation
 ROOTD=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/.." && pwd)
-[[ -d "$ROOTD/pulp_cluster/pulp-runtime" ]] && source "$ROOTD/pulp_cluster/pulp-runtime/configs/carfield-cluster.sh"
+[[ -d "$ROOTD/pulp_cluster/pulp-runtime" ]] && source "$ROOTD/pulp_cluster/pulp-runtime/configs/astral-cluster.sh"

--- a/hw/carfield.sv
+++ b/hw/carfield.sv
@@ -428,7 +428,6 @@ logic [    LogDepth:0] llc_w_rptr;
 
 logic hyper_isolate_req, hyper_isolated_rsp;
 logic security_island_isolate_req;
-logic unused;
 
 logic [iomsb(Cfg.AxiExtNumSlv):0] slave_isolate_req, slave_isolated_rsp, slave_isolated;
 logic [iomsb(Cfg.AxiExtNumMst):0] master_isolated_rsp;
@@ -1682,7 +1681,7 @@ if (CarfieldIslandsCfg.secured.enable) begin : gen_secure_subsystem
                    narrow_axi_data_t, narrow_axi_strb_t, narrow_axi_user_t)
 
   `ifndef SECD_NETLIST
-  secure_subsystem_synth_wrap_astral #(
+  security_island #(
     .HartIdOffs            ( OpnTitHartIdOffs                  ),
     .AxiAddrWidth          ( Cfg.AddrWidth                     ),
     .AxiDataWidth          ( Cfg.AxiDataWidth                  ),
@@ -1765,7 +1764,7 @@ if (CarfieldIslandsCfg.secured.enable) begin : gen_secure_subsystem
     .async_idma_axi_out_r_wptr_i  ( axi_mst_ext_r_wptr  [SecurityIslandiDMAMstIdx] ),
     .async_idma_axi_out_r_rptr_o  ( axi_mst_ext_r_rptr  [SecurityIslandiDMAMstIdx] ),
     .axi_isolate_i    ( security_island_isolate_req                                ),
-    .axi_isolated_o   ( { master_isolated_rsp[SecurityIslandiDMAMstIdx] master_isolated_rsp[SecurityIslandTlulMstIdx] } ),
+    .axi_isolated_o   ( { master_isolated_rsp[SecurityIslandiDMAMstIdx], master_isolated_rsp[SecurityIslandTlulMstIdx] } ),
      // Uart
     .ibex_uart_rx_i   ( uart_ot_rx_i  ),
     .ibex_uart_tx_o   ( uart_ot_tx_o  ),

--- a/hw/carfield.sv
+++ b/hw/carfield.sv
@@ -1678,7 +1678,8 @@ if (CarfieldIslandsCfg.secured.enable) begin : gen_secure_subsystem
   typedef logic [Cfg.AxiUserWidth-1:0]     narrow_axi_user_t;
   typedef logic [Cfg.AxiMstIdWidth-1:0]    narrow_axi_out_id_t;
 
-  `AXI_TYPEDEF_ALL(carfield_axi_mst_narrow, narrow_axi_addr_t, narrow_axi_out_id_t, narrow_axi_data_t, narrow_axi_strb_t, narrow_axi_user_t)
+  `AXI_TYPEDEF_ALL(carfield_axi_mst_narrow, narrow_axi_addr_t, narrow_axi_out_id_t, \
+                   narrow_axi_data_t, narrow_axi_strb_t, narrow_axi_user_t)
 
   `ifndef SECD_NETLIST
   secure_subsystem_synth_wrap_astral #(

--- a/hw/carfield.sv
+++ b/hw/carfield.sv
@@ -1668,7 +1668,7 @@ if (CarfieldIslandsCfg.secured.enable) begin : gen_secure_subsystem
   assign security_island_isolate_req  = car_regs_reg2hw.security_island_isolate.q &&
                                         !secure_boot_i;
   assign car_regs_hw2reg.security_island_isolate_status.d =
-         master_isolated_rsp[SecurityIslandTlulMstIdx] 
+         master_isolated_rsp[SecurityIslandTlulMstIdx]
          & master_isolated_rsp[SecurityIslandiDMAMstIdx];
   assign car_regs_hw2reg.security_island_isolate_status.de = 1'b1;
 

--- a/hw/carfield.sv
+++ b/hw/carfield.sv
@@ -1672,38 +1672,46 @@ if (CarfieldIslandsCfg.secured.enable) begin : gen_secure_subsystem
          master_isolated_rsp[SecurityIslandTlulMstIdx];
   assign car_regs_hw2reg.security_island_isolate_status.de = 1'b1;
 
+  typedef logic [Cfg.AddrWidth-1:0]        narrow_axi_addr_t;
+  typedef logic [AxiNarrowDataWidth-1:0]   narrow_axi_data_t;
+  typedef logic [AxiNarrowDataWidth/8-1:0] narrow_axi_strb_t;
+  typedef logic [Cfg.AxiUserWidth-1:0]     narrow_axi_user_t;
+  typedef logic [Cfg.AxiMstIdWidth-1:0]    narrow_axi_out_id_t;
+
+  `AXI_TYPEDEF_ALL(carfield_axi_mst_narrow, narrow_axi_addr_t, narrow_axi_out_id_t, narrow_axi_data_t, narrow_axi_strb_t, narrow_axi_user_t)
+
   `ifndef SECD_NETLIST
   secure_subsystem_synth_wrap_astral #(
-    .HartIdOffs            ( OpnTitHartIdOffs           ),
-    .AxiAddrWidth          ( Cfg.AddrWidth              ),
-    .AxiDataWidth          ( Cfg.AxiDataWidth           ),
-    .AxiUserWidth          ( Cfg.AxiUserWidth           ),
-    .AxiOutIdWidth         ( Cfg.AxiMstIdWidth          ),
-    .AxiOtAddrWidth        ( Cfg.AddrWidth              ),
-    .AxiOtDataWidth        ( AxiNarrowDataWidth         ), // TODO: why is this exposed?
-    .AxiOtUserWidth        ( Cfg.AxiUserWidth           ),
-    .AxiOtOutIdWidth       ( Cfg.AxiMstIdWidth          ),
-    .AsyncAxiOutAwWidth    ( CarfieldAxiMstAwWidth      ),
-    .AsyncAxiOutWWidth     ( CarfieldAxiMstWWidth       ),
-    .AsyncAxiOutBWidth     ( CarfieldAxiMstBWidth       ),
-    .AsyncAxiOutArWidth    ( CarfieldAxiMstArWidth      ),
-    .AsyncAxiOutRWidth     ( CarfieldAxiMstRWidth       ),
-    .axi_out_aw_chan_t     ( carfield_axi_mst_aw_chan_t ),
-    .axi_out_w_chan_t      ( carfield_axi_mst_w_chan_t  ),
-    .axi_out_b_chan_t      ( carfield_axi_mst_b_chan_t  ),
-    .axi_out_ar_chan_t     ( carfield_axi_mst_ar_chan_t ),
-    .axi_out_r_chan_t      ( carfield_axi_mst_r_chan_t  ),
-    .axi_out_req_t         ( carfield_axi_mst_req_t     ),
-    .axi_out_resp_t        ( carfield_axi_mst_rsp_t     ),
-    .axi_ot_out_aw_chan_t  ( carfield_axi_mst_aw_chan_t ),
-    .axi_ot_out_w_chan_t   ( carfield_axi_mst_w_chan_t  ),
-    .axi_ot_out_b_chan_t   ( carfield_axi_mst_b_chan_t  ),
-    .axi_ot_out_ar_chan_t  ( carfield_axi_mst_ar_chan_t ),
-    .axi_ot_out_r_chan_t   ( carfield_axi_mst_r_chan_t  ),
-    .axi_ot_out_req_t      ( carfield_axi_mst_req_t     ),
-    .axi_ot_out_resp_t     ( carfield_axi_mst_rsp_t     ),
-    .CdcSyncStages         ( SyncStages                 ),
-    .SyncStages            ( SyncStages                 )
+    .HartIdOffs            ( 4           ),
+    .AxiAddrWidth          ( Cfg.AddrWidth                     ),
+    .AxiDataWidth          ( Cfg.AxiDataWidth                  ),
+    .AxiUserWidth          ( Cfg.AxiUserWidth                  ),
+    .AxiOutIdWidth         ( Cfg.AxiMstIdWidth                 ),
+    .AxiOtAddrWidth        ( Cfg.AddrWidth                     ),
+    .AxiOtDataWidth        ( AxiNarrowDataWidth                ), // TODO: why is this exposed?
+    .AxiOtUserWidth        ( Cfg.AxiUserWidth                  ),
+    .AxiOtOutIdWidth       ( Cfg.AxiMstIdWidth                 ),
+    .AsyncAxiOutAwWidth    ( CarfieldAxiMstAwWidth             ),
+    .AsyncAxiOutWWidth     ( CarfieldAxiMstWWidth              ),
+    .AsyncAxiOutBWidth     ( CarfieldAxiMstBWidth              ),
+    .AsyncAxiOutArWidth    ( CarfieldAxiMstArWidth             ),
+    .AsyncAxiOutRWidth     ( CarfieldAxiMstRWidth              ),
+    .axi_out_aw_chan_t     ( carfield_axi_mst_aw_chan_t        ),
+    .axi_out_w_chan_t      ( carfield_axi_mst_w_chan_t         ),
+    .axi_out_b_chan_t      ( carfield_axi_mst_b_chan_t         ),
+    .axi_out_ar_chan_t     ( carfield_axi_mst_ar_chan_t        ),
+    .axi_out_r_chan_t      ( carfield_axi_mst_r_chan_t         ),
+    .axi_out_req_t         ( carfield_axi_mst_req_t            ),
+    .axi_out_resp_t        ( carfield_axi_mst_rsp_t            ),
+    .axi_ot_out_aw_chan_t  ( carfield_axi_mst_narrow_aw_chan_t ),
+    .axi_ot_out_w_chan_t   ( carfield_axi_mst_narrow_w_chan_t  ),
+    .axi_ot_out_b_chan_t   ( carfield_axi_mst_narrow_b_chan_t  ),
+    .axi_ot_out_ar_chan_t  ( carfield_axi_mst_narrow_ar_chan_t ),
+    .axi_ot_out_r_chan_t   ( carfield_axi_mst_narrow_r_chan_t  ),
+    .axi_ot_out_req_t      ( carfield_axi_mst_narrow_req_t     ),
+    .axi_ot_out_resp_t     ( carfield_axi_mst_narrow_resp_t    ),
+    .CdcSyncStages         ( SyncStages                        ),
+    .SyncStages            ( SyncStages                        )
   ) i_security_island (
   `else
   security_island i_security_island (

--- a/hw/carfield.sv
+++ b/hw/carfield.sv
@@ -1678,7 +1678,7 @@ if (CarfieldIslandsCfg.secured.enable) begin : gen_secure_subsystem
   typedef logic [Cfg.AxiUserWidth-1:0]     narrow_axi_user_t;
   typedef logic [Cfg.AxiMstIdWidth-1:0]    narrow_axi_out_id_t;
 
-  `AXI_TYPEDEF_ALL(carfield_axi_mst_narrow, narrow_axi_addr_t, narrow_axi_out_id_t, \
+  `AXI_TYPEDEF_ALL(carfield_axi_mst_narrow, narrow_axi_addr_t, narrow_axi_out_id_t,
                    narrow_axi_data_t, narrow_axi_strb_t, narrow_axi_user_t)
 
   `ifndef SECD_NETLIST

--- a/hw/carfield.sv
+++ b/hw/carfield.sv
@@ -1669,7 +1669,7 @@ if (CarfieldIslandsCfg.secured.enable) begin : gen_secure_subsystem
   assign security_island_isolate_req  = car_regs_reg2hw.security_island_isolate.q &&
                                         !secure_boot_i;
   assign car_regs_hw2reg.security_island_isolate_status.d =
-         master_isolated_rsp[SecurityIslandTlulMstIdx];
+         master_isolated_rsp[SecurityIslandTlulMstIdx] & master_isolated_rsp[SecurityIslandiDMAMstIdx];
   assign car_regs_hw2reg.security_island_isolate_status.de = 1'b1;
 
   typedef logic [Cfg.AddrWidth-1:0]        narrow_axi_addr_t;
@@ -1683,7 +1683,7 @@ if (CarfieldIslandsCfg.secured.enable) begin : gen_secure_subsystem
 
   `ifndef SECD_NETLIST
   secure_subsystem_synth_wrap_astral #(
-    .HartIdOffs            ( 4           ),
+    .HartIdOffs            ( OpnTitHartIdOffs                  ),
     .AxiAddrWidth          ( Cfg.AddrWidth                     ),
     .AxiDataWidth          ( Cfg.AxiDataWidth                  ),
     .AxiUserWidth          ( Cfg.AxiUserWidth                  ),
@@ -1764,8 +1764,8 @@ if (CarfieldIslandsCfg.secured.enable) begin : gen_secure_subsystem
     .async_idma_axi_out_r_data_i  ( axi_mst_ext_r_data  [SecurityIslandiDMAMstIdx] ),
     .async_idma_axi_out_r_wptr_i  ( axi_mst_ext_r_wptr  [SecurityIslandiDMAMstIdx] ),
     .async_idma_axi_out_r_rptr_o  ( axi_mst_ext_r_rptr  [SecurityIslandiDMAMstIdx] ),
-    .axi_isolate_i    ( {'0, security_island_isolate_req                    }         ),
-    .axi_isolated_o   ( { unused, master_isolated_rsp[SecurityIslandTlulMstIdx] } ),
+    .axi_isolate_i    ( security_island_isolate_req                                ),
+    .axi_isolated_o   ( { master_isolated_rsp[SecurityIslandiDMAMstIdx] master_isolated_rsp[SecurityIslandTlulMstIdx] } ),
      // Uart
     .ibex_uart_rx_i   ( uart_ot_rx_i  ),
     .ibex_uart_tx_o   ( uart_ot_tx_o  ),

--- a/hw/carfield.sv
+++ b/hw/carfield.sv
@@ -1320,7 +1320,7 @@ if (CarfieldIslandsCfg.pulp.enable) begin : gen_pulp_cluster
 
 localparam pulp_cluster_package::pulp_cluster_cfg_t PulpClusterCfg = '{
   CoreType: pulp_cluster_package::RISCY,
-  NumCores: 12,
+  NumCores: IntClusterNumCores,
   DmaNumPlugs: 4,
   DmaNumOutstandingBursts: 8,
   DmaBurstLength: 256,
@@ -1330,9 +1330,13 @@ localparam pulp_cluster_package::pulp_cluster_cfg_t PulpClusterCfg = '{
   ClusterAliasBase: 'h0,
   NumSyncStages: 3,
   UseHci: 1,
-  TcdmSize: 256*1024,
+  TcdmSize: 128*1024,
   TcdmNumBank: 16,
   HwpePresent: 1,
+  HwpeCfg: '{NumHwpes: 2,
+             HwpeList: {pulp_cluster_package::NEUREKA,
+                        pulp_cluster_package::REDMULE}
+            },
   HwpeNumPorts: 9,
   iCacheNumBanks: 2,
   iCacheNumLines: 1,
@@ -1347,7 +1351,7 @@ localparam pulp_cluster_package::pulp_cluster_cfg_t PulpClusterCfg = '{
               safety_island_pkg::DebugAddrOffset,
   BootRomBaseAddr: carfield_pkg::CarfieldIslandsCfg.l2_port0.base + 'h8080,
   BootAddr: carfield_pkg::CarfieldIslandsCfg.l2_port0.base + 'h8080,
-  EnablePrivateFpu: 0,
+  EnablePrivateFpu: 1,
   EnablePrivateFpDivSqrt: 0,
   EnableSharedFpu: 0,
   EnableSharedFpDivSqrt: 0,

--- a/hw/carfield.sv
+++ b/hw/carfield.sv
@@ -428,6 +428,7 @@ logic [    LogDepth:0] llc_w_rptr;
 
 logic hyper_isolate_req, hyper_isolated_rsp;
 logic security_island_isolate_req;
+logic unused;
 
 logic [iomsb(Cfg.AxiExtNumSlv):0] slave_isolate_req, slave_isolated_rsp, slave_isolated;
 logic [iomsb(Cfg.AxiExtNumMst):0] master_isolated_rsp;
@@ -1668,11 +1669,11 @@ if (CarfieldIslandsCfg.secured.enable) begin : gen_secure_subsystem
   assign security_island_isolate_req  = car_regs_reg2hw.security_island_isolate.q &&
                                         !secure_boot_i;
   assign car_regs_hw2reg.security_island_isolate_status.d =
-         master_isolated_rsp[SecurityIslandMstIdx];
+         master_isolated_rsp[SecurityIslandTlulMstIdx];
   assign car_regs_hw2reg.security_island_isolate_status.de = 1'b1;
 
   `ifndef SECD_NETLIST
-  secure_subsystem_synth_wrap #(
+  secure_subsystem_synth_wrap_astral #(
     .HartIdOffs            ( OpnTitHartIdOffs           ),
     .AxiAddrWidth          ( Cfg.AddrWidth              ),
     .AxiDataWidth          ( Cfg.AxiDataWidth           ),
@@ -1723,23 +1724,39 @@ if (CarfieldIslandsCfg.secured.enable) begin : gen_secure_subsystem
     .jtag_tdo_o       ( jtag_ot_tdo_o   ),
     .jtag_tdo_oe_o    ( jtag_ot_tdo_oe_o),
      // Asynch axi port
-    .async_axi_out_aw_data_o ( axi_mst_ext_aw_data [SecurityIslandMstIdx] ),
-    .async_axi_out_aw_wptr_o ( axi_mst_ext_aw_wptr [SecurityIslandMstIdx] ),
-    .async_axi_out_aw_rptr_i ( axi_mst_ext_aw_rptr [SecurityIslandMstIdx] ),
-    .async_axi_out_w_data_o  ( axi_mst_ext_w_data  [SecurityIslandMstIdx] ),
-    .async_axi_out_w_wptr_o  ( axi_mst_ext_w_wptr  [SecurityIslandMstIdx] ),
-    .async_axi_out_w_rptr_i  ( axi_mst_ext_w_rptr  [SecurityIslandMstIdx] ),
-    .async_axi_out_b_data_i  ( axi_mst_ext_b_data  [SecurityIslandMstIdx] ),
-    .async_axi_out_b_wptr_i  ( axi_mst_ext_b_wptr  [SecurityIslandMstIdx] ),
-    .async_axi_out_b_rptr_o  ( axi_mst_ext_b_rptr  [SecurityIslandMstIdx] ),
-    .async_axi_out_ar_data_o ( axi_mst_ext_ar_data [SecurityIslandMstIdx] ),
-    .async_axi_out_ar_wptr_o ( axi_mst_ext_ar_wptr [SecurityIslandMstIdx] ),
-    .async_axi_out_ar_rptr_i ( axi_mst_ext_ar_rptr [SecurityIslandMstIdx] ),
-    .async_axi_out_r_data_i  ( axi_mst_ext_r_data  [SecurityIslandMstIdx] ),
-    .async_axi_out_r_wptr_i  ( axi_mst_ext_r_wptr  [SecurityIslandMstIdx] ),
-    .async_axi_out_r_rptr_o  ( axi_mst_ext_r_rptr  [SecurityIslandMstIdx] ),
-    .axi_isolate_i    ( security_island_isolate_req                ),
-    .axi_isolated_o   ( master_isolated_rsp[SecurityIslandMstIdx] ),
+    .async_axi_out_aw_data_o ( axi_mst_ext_aw_data [SecurityIslandTlulMstIdx] ),
+    .async_axi_out_aw_wptr_o ( axi_mst_ext_aw_wptr [SecurityIslandTlulMstIdx] ),
+    .async_axi_out_aw_rptr_i ( axi_mst_ext_aw_rptr [SecurityIslandTlulMstIdx] ),
+    .async_axi_out_w_data_o  ( axi_mst_ext_w_data  [SecurityIslandTlulMstIdx] ),
+    .async_axi_out_w_wptr_o  ( axi_mst_ext_w_wptr  [SecurityIslandTlulMstIdx] ),
+    .async_axi_out_w_rptr_i  ( axi_mst_ext_w_rptr  [SecurityIslandTlulMstIdx] ),
+    .async_axi_out_b_data_i  ( axi_mst_ext_b_data  [SecurityIslandTlulMstIdx] ),
+    .async_axi_out_b_wptr_i  ( axi_mst_ext_b_wptr  [SecurityIslandTlulMstIdx] ),
+    .async_axi_out_b_rptr_o  ( axi_mst_ext_b_rptr  [SecurityIslandTlulMstIdx] ),
+    .async_axi_out_ar_data_o ( axi_mst_ext_ar_data [SecurityIslandTlulMstIdx] ),
+    .async_axi_out_ar_wptr_o ( axi_mst_ext_ar_wptr [SecurityIslandTlulMstIdx] ),
+    .async_axi_out_ar_rptr_i ( axi_mst_ext_ar_rptr [SecurityIslandTlulMstIdx] ),
+    .async_axi_out_r_data_i  ( axi_mst_ext_r_data  [SecurityIslandTlulMstIdx] ),
+    .async_axi_out_r_wptr_i  ( axi_mst_ext_r_wptr  [SecurityIslandTlulMstIdx] ),
+    .async_axi_out_r_rptr_o  ( axi_mst_ext_r_rptr  [SecurityIslandTlulMstIdx] ),
+
+    .async_idma_axi_out_aw_data_o ( axi_mst_ext_aw_data [SecurityIslandiDMAMstIdx] ),
+    .async_idma_axi_out_aw_wptr_o ( axi_mst_ext_aw_wptr [SecurityIslandiDMAMstIdx] ),
+    .async_idma_axi_out_aw_rptr_i ( axi_mst_ext_aw_rptr [SecurityIslandiDMAMstIdx] ),
+    .async_idma_axi_out_w_data_o  ( axi_mst_ext_w_data  [SecurityIslandiDMAMstIdx] ),
+    .async_idma_axi_out_w_wptr_o  ( axi_mst_ext_w_wptr  [SecurityIslandiDMAMstIdx] ),
+    .async_idma_axi_out_w_rptr_i  ( axi_mst_ext_w_rptr  [SecurityIslandiDMAMstIdx] ),
+    .async_idma_axi_out_b_data_i  ( axi_mst_ext_b_data  [SecurityIslandiDMAMstIdx] ),
+    .async_idma_axi_out_b_wptr_i  ( axi_mst_ext_b_wptr  [SecurityIslandiDMAMstIdx] ),
+    .async_idma_axi_out_b_rptr_o  ( axi_mst_ext_b_rptr  [SecurityIslandiDMAMstIdx] ),
+    .async_idma_axi_out_ar_data_o ( axi_mst_ext_ar_data [SecurityIslandiDMAMstIdx] ),
+    .async_idma_axi_out_ar_wptr_o ( axi_mst_ext_ar_wptr [SecurityIslandiDMAMstIdx] ),
+    .async_idma_axi_out_ar_rptr_i ( axi_mst_ext_ar_rptr [SecurityIslandiDMAMstIdx] ),
+    .async_idma_axi_out_r_data_i  ( axi_mst_ext_r_data  [SecurityIslandiDMAMstIdx] ),
+    .async_idma_axi_out_r_wptr_i  ( axi_mst_ext_r_wptr  [SecurityIslandiDMAMstIdx] ),
+    .async_idma_axi_out_r_rptr_o  ( axi_mst_ext_r_rptr  [SecurityIslandiDMAMstIdx] ),
+    .axi_isolate_i    ( {'0, security_island_isolate_req                    }         ),
+    .axi_isolated_o   ( { unused, master_isolated_rsp[SecurityIslandTlulMstIdx] } ),
      // Uart
     .ibex_uart_rx_i   ( uart_ot_rx_i  ),
     .ibex_uart_tx_o   ( uart_ot_tx_o  ),
@@ -1750,7 +1767,9 @@ if (CarfieldIslandsCfg.secured.enable) begin : gen_secure_subsystem
     .spi_host_CSB_en_o( spih_ot_csb_en_o ),
     .spi_host_SD_o    ( spih_ot_sd_o     ),
     .spi_host_SD_i    ( spih_ot_sd_i     ),
-    .spi_host_SD_en_o ( spih_ot_sd_en_o  )
+    .spi_host_SD_en_o ( spih_ot_sd_en_o  ),
+    .gpio_0_i         ( '0               ),
+    .gpio_1_i         ( '0               )
   );
 end else begin : gen_no_secure_subsystem
   assign hostd_secd_mbox_intr = '0;

--- a/hw/carfield.sv
+++ b/hw/carfield.sv
@@ -432,7 +432,7 @@ logic security_island_isolate_req;
 logic [iomsb(Cfg.AxiExtNumSlv):0] slave_isolate_req, slave_isolated_rsp, slave_isolated;
 logic [iomsb(Cfg.AxiExtNumMst):0] master_isolated_rsp;
 
-// All AXI Slaves (except the Integer Cluster and the Mailbox)
+// All AXI Slaves (except the Mailbox)
 logic [iomsb(NumSlaveCDCs):0][CarfieldAxiSlvAwWidth-1:0] axi_slv_ext_aw_data;
 logic [iomsb(NumSlaveCDCs):0][               LogDepth:0] axi_slv_ext_aw_wptr;
 logic [iomsb(NumSlaveCDCs):0][               LogDepth:0] axi_slv_ext_aw_rptr;
@@ -449,7 +449,7 @@ logic [iomsb(NumSlaveCDCs):0][ CarfieldAxiSlvRWidth-1:0] axi_slv_ext_r_data ;
 logic [iomsb(NumSlaveCDCs):0][               LogDepth:0] axi_slv_ext_r_wptr ;
 logic [iomsb(NumSlaveCDCs):0][               LogDepth:0] axi_slv_ext_r_rptr ;
 
-// All AXI Masters (except the Integer Cluster)
+// All AXI Masters
 logic [iomsb(Cfg.AxiExtNumMst):0][CarfieldAxiMstAwWidth-1:0] axi_mst_ext_aw_data;
 logic [iomsb(Cfg.AxiExtNumMst):0][               LogDepth:0] axi_mst_ext_aw_wptr;
 logic [iomsb(Cfg.AxiExtNumMst):0][               LogDepth:0] axi_mst_ext_aw_rptr;
@@ -767,6 +767,7 @@ cheshire_wrap #(
   .cheshire_reg_ext_rsp_t         ( carfield_reg_rsp_t           ),
   .LogDepth                       ( LogDepth                     ),
   .CdcSyncStages                  ( SyncStages                   ),
+  .NumSlaveCDCs                   ( NumSlaveCDCs                 ),
   .AxiIn                          ( AxiIn                        ),
   .AxiOut                         ( AxiOut                       )
 ) i_cheshire_wrap                 (
@@ -796,7 +797,7 @@ cheshire i_cheshire_wrap                 (
   .llc_mst_w_data_o   ( llc_w_data         ),
   .llc_mst_w_wptr_o   ( llc_w_wptr         ),
   .llc_mst_w_rptr_i   ( llc_w_rptr         ),
-  // External AXI slave devices (except the Integer Cluster)
+  // External AXI slave devices
   .axi_ext_slv_isolate_i  ( slave_isolate_req   ),
   .axi_ext_slv_isolated_o ( slave_isolated_rsp  ),
   .axi_ext_slv_ar_data_o  ( axi_slv_ext_ar_data ),
@@ -814,7 +815,7 @@ cheshire i_cheshire_wrap                 (
   .axi_ext_slv_w_data_o   ( axi_slv_ext_w_data  ),
   .axi_ext_slv_w_wptr_o   ( axi_slv_ext_w_wptr  ),
   .axi_ext_slv_w_rptr_i   ( axi_slv_ext_w_rptr  ),
-  // External AXI master devices (except the Integer Cluster)
+  // External AXI master devices
   .axi_ext_mst_ar_data_i ( axi_mst_ext_ar_data ),
   .axi_ext_mst_ar_wptr_i ( axi_mst_ext_ar_wptr ),
   .axi_ext_mst_ar_rptr_o ( axi_mst_ext_ar_rptr ),

--- a/hw/carfield.sv
+++ b/hw/carfield.sv
@@ -1668,7 +1668,8 @@ if (CarfieldIslandsCfg.secured.enable) begin : gen_secure_subsystem
   assign security_island_isolate_req  = car_regs_reg2hw.security_island_isolate.q &&
                                         !secure_boot_i;
   assign car_regs_hw2reg.security_island_isolate_status.d =
-         master_isolated_rsp[SecurityIslandTlulMstIdx] & master_isolated_rsp[SecurityIslandiDMAMstIdx];
+         master_isolated_rsp[SecurityIslandTlulMstIdx] 
+         & master_isolated_rsp[SecurityIslandiDMAMstIdx];
   assign car_regs_hw2reg.security_island_isolate_status.de = 1'b1;
 
   typedef logic [Cfg.AddrWidth-1:0]        narrow_axi_addr_t;
@@ -1764,7 +1765,8 @@ if (CarfieldIslandsCfg.secured.enable) begin : gen_secure_subsystem
     .async_idma_axi_out_r_wptr_i  ( axi_mst_ext_r_wptr  [SecurityIslandiDMAMstIdx] ),
     .async_idma_axi_out_r_rptr_o  ( axi_mst_ext_r_rptr  [SecurityIslandiDMAMstIdx] ),
     .axi_isolate_i    ( security_island_isolate_req                                ),
-    .axi_isolated_o   ( { master_isolated_rsp[SecurityIslandiDMAMstIdx], master_isolated_rsp[SecurityIslandTlulMstIdx] } ),
+    .axi_isolated_o   ( { master_isolated_rsp[SecurityIslandiDMAMstIdx],
+                          master_isolated_rsp[SecurityIslandTlulMstIdx] }          ),
      // Uart
     .ibex_uart_rx_i   ( uart_ot_rx_i  ),
     .ibex_uart_tx_o   ( uart_ot_tx_o  ),

--- a/hw/carfield_pkg.sv
+++ b/hw/carfield_pkg.sv
@@ -40,6 +40,7 @@ typedef struct packed {
   islands_properties_t spatz;
   islands_properties_t pulp;
   islands_properties_t secured;
+  islands_properties_t secured_idma;
   islands_properties_t mbox;
 } islands_cfg_t;
 
@@ -122,10 +123,10 @@ endfunction
 // crossbar starting from the islands enable structure.
 function automatic int unsigned gen_num_axi_master(islands_cfg_t island_cfg);
   int unsigned ret = 0; // Number of masters starts from 0
-  if (island_cfg.safed.enable  )      begin ret++; end
-  if (island_cfg.spatz.enable  )      begin ret++; end
-  if (island_cfg.pulp.enable   )      begin ret++; end
-  if (island_cfg.secured.enable)      begin ret+=2; end
+  if (island_cfg.safed.enable  ) begin ret++; end
+  if (island_cfg.spatz.enable  ) begin ret++; end
+  if (island_cfg.pulp.enable   ) begin ret++; end
+  if (island_cfg.secured.enable) begin ret+=2; end
   return ret;
 endfunction
 

--- a/hw/carfield_pkg.sv
+++ b/hw/carfield_pkg.sv
@@ -41,6 +41,7 @@ typedef struct packed {
   islands_properties_t pulp;
   islands_properties_t secured;
   islands_properties_t mbox;
+  islands_properties_t secured_idma;
 } islands_cfg_t;
 
 // Types are obtained from Cheshire package
@@ -71,6 +72,7 @@ typedef struct packed {
   byte_bt spatz;
   byte_bt secured;
   byte_bt pulp;
+  byte_bt secured_idma;
 } carfield_master_idx_t;
 
 // Generate the number of AXI slave devices to be connected to the
@@ -316,15 +318,16 @@ function automatic int unsigned gen_carfield_domains(islands_cfg_t island_cfg);
 endfunction
 
 localparam islands_cfg_t CarfieldIslandsCfg = '{
-  l2_port0: '{L2Port0Enable, L2Port0Base, L2Port0Size},
-  l2_port1: '{L2Port1Enable, L2Port1Base, L2Port1Size},
-  safed:    '{SafetyIslandEnable, SafetyIslandBase, SafetyIslandSize},
-  ethernet: '{EthernetEnable, EthernetBase, EthernetSize},
-  periph:   '{PeriphEnable, PeriphBase, PeriphSize},
-  spatz:    '{SpatzClusterEnable, SpatzClusterBase, SpatzClusterSize},
-  pulp:     '{PulpClusterEnable, PulpClusterBase, PulpClusterSize},
-  secured:  '{SecurityIslandEnable, SecurityIslandBase, SecurityIslandSize},
-  mbox:     '{MailboxEnable, MailboxBase, MailboxSize}
+  l2_port0:      '{L2Port0Enable, L2Port0Base, L2Port0Size},
+  l2_port1:      '{L2Port1Enable, L2Port1Base, L2Port1Size},
+  safed:         '{SafetyIslandEnable, SafetyIslandBase, SafetyIslandSize},
+  ethernet:      '{EthernetEnable, EthernetBase, EthernetSize},
+  periph:        '{PeriphEnable, PeriphBase, PeriphSize},
+  spatz:         '{SpatzClusterEnable, SpatzClusterBase, SpatzClusterSize},
+  pulp:          '{PulpClusterEnable, PulpClusterBase, PulpClusterSize},
+  secured:       '{SecurityIslandEnable, SecurityIslandBase, SecurityIslandSize},
+  mbox:          '{MailboxEnable, MailboxBase, MailboxSize},
+  secured_idma:  '{SecurityIslandEnable, SecurityIslandBase, SecurityIslandSize}
 };
 
 localparam int unsigned CarfieldAxiNumSlaves  = gen_num_axi_slave(CarfieldIslandsCfg);
@@ -416,10 +419,11 @@ typedef enum byte_bt {
 } axi_slv_idx_t;
 
 typedef enum byte_bt {
-  SafetyIslandMstIdx   = CarfieldMstIdx.safed,
-  SecurityIslandMstIdx = CarfieldMstIdx.secured,
-  FPClusterMstIdx      = CarfieldMstIdx.spatz,
-  IntClusterMstIdx     = CarfieldMstIdx.pulp
+  SafetyIslandMstIdx       = CarfieldMstIdx.safed,
+  SecurityIslandTlulMstIdx = CarfieldMstIdx.secured,
+  FPClusterMstIdx          = CarfieldMstIdx.spatz,
+  IntClusterMstIdx         = CarfieldMstIdx.pulp,
+  SecurityIslandiDMAMstIdx = CarfieldMstIdx.secured_idma
 } axi_mst_idx_t;
 
 // APB peripherals

--- a/hw/carfield_pkg.sv
+++ b/hw/carfield_pkg.sv
@@ -454,7 +454,7 @@ typedef enum hartid_t {
 
 
 localparam int unsigned MaxHartId = 63;
-localparam int unsigned IntClusterNumCores = 12;
+localparam int unsigned IntClusterNumCores = 8;
 localparam bit [MaxHartId:0] SafetyIslandExtHarts =
   {MaxHartId+1{1'b0}} | (((1<<IntClusterNumCores) - 1) << PulpHartIdOffs);
 

--- a/hw/carfield_pkg.sv
+++ b/hw/carfield_pkg.sv
@@ -71,8 +71,8 @@ typedef struct packed {
   byte_bt safed;
   byte_bt spatz;
   byte_bt secured;
-  byte_bt pulp;
   byte_bt secured_idma;
+  byte_bt pulp;
 } carfield_master_idx_t;
 
 // Generate the number of AXI slave devices to be connected to the
@@ -123,10 +123,11 @@ endfunction
 // crossbar starting from the islands enable structure.
 function automatic int unsigned gen_num_axi_master(islands_cfg_t island_cfg);
   int unsigned ret = 0; // Number of masters starts from 0
-  if (island_cfg.safed.enable  ) begin ret++; end
-  if (island_cfg.spatz.enable  ) begin ret++; end
-  if (island_cfg.pulp.enable   ) begin ret++; end
-  if (island_cfg.secured.enable) begin ret++; end
+  if (island_cfg.safed.enable  )      begin ret++; end
+  if (island_cfg.spatz.enable  )      begin ret++; end
+  if (island_cfg.pulp.enable   )      begin ret++; end
+  if (island_cfg.secured.enable)      begin ret++; end
+  if (island_cfg.secured.enable)      begin ret++; end
   return ret;
 endfunction
 
@@ -142,6 +143,8 @@ function automatic carfield_master_idx_t carfield_gen_axi_master_idx(islands_cfg
   end else begin ret.secured = MaxExtAxiMst + j; j++; end
   if (island_cfg.spatz.enable) begin ret.spatz = i; i++;
   end else begin ret.spatz = MaxExtAxiMst + j; j++; end
+  if (island_cfg.secured.enable) begin ret.secured_idma = i; i++;
+  end else begin ret.secured_idma = MaxExtAxiMst + j; j++; end
   if (island_cfg.pulp.enable) begin ret.pulp = i; i++;
   end else begin ret.pulp = MaxExtAxiMst + j; j++; end
   return ret;
@@ -422,8 +425,8 @@ typedef enum byte_bt {
   SafetyIslandMstIdx       = CarfieldMstIdx.safed,
   SecurityIslandTlulMstIdx = CarfieldMstIdx.secured,
   FPClusterMstIdx          = CarfieldMstIdx.spatz,
-  IntClusterMstIdx         = CarfieldMstIdx.pulp,
-  SecurityIslandiDMAMstIdx = CarfieldMstIdx.secured_idma
+  SecurityIslandiDMAMstIdx = CarfieldMstIdx.secured_idma,
+  IntClusterMstIdx         = CarfieldMstIdx.pulp
 } axi_mst_idx_t;
 
 // APB peripherals

--- a/hw/carfield_pkg.sv
+++ b/hw/carfield_pkg.sv
@@ -40,7 +40,6 @@ typedef struct packed {
   islands_properties_t spatz;
   islands_properties_t pulp;
   islands_properties_t secured;
-  islands_properties_t secured_idma;
   islands_properties_t mbox;
 } islands_cfg_t;
 
@@ -326,8 +325,7 @@ localparam islands_cfg_t CarfieldIslandsCfg = '{
   spatz:         '{SpatzClusterEnable, SpatzClusterBase, SpatzClusterSize},
   pulp:          '{PulpClusterEnable, PulpClusterBase, PulpClusterSize},
   secured:       '{SecurityIslandEnable, SecurityIslandBase, SecurityIslandSize},
-  mbox:          '{MailboxEnable, MailboxBase, MailboxSize},
-  secured_idma:  '{SecurityIslandEnable, SecurityIslandBase, SecurityIslandSize}
+  mbox:          '{MailboxEnable, MailboxBase, MailboxSize}
 };
 
 localparam int unsigned CarfieldAxiNumSlaves  = gen_num_axi_slave(CarfieldIslandsCfg);

--- a/hw/carfield_pkg.sv
+++ b/hw/carfield_pkg.sv
@@ -41,7 +41,6 @@ typedef struct packed {
   islands_properties_t pulp;
   islands_properties_t secured;
   islands_properties_t mbox;
-  islands_properties_t secured_idma;
 } islands_cfg_t;
 
 // Types are obtained from Cheshire package
@@ -126,8 +125,7 @@ function automatic int unsigned gen_num_axi_master(islands_cfg_t island_cfg);
   if (island_cfg.safed.enable  )      begin ret++; end
   if (island_cfg.spatz.enable  )      begin ret++; end
   if (island_cfg.pulp.enable   )      begin ret++; end
-  if (island_cfg.secured.enable)      begin ret++; end
-  if (island_cfg.secured.enable)      begin ret++; end
+  if (island_cfg.secured.enable)      begin ret+=2; end
   return ret;
 endfunction
 
@@ -139,12 +137,10 @@ function automatic carfield_master_idx_t carfield_gen_axi_master_idx(islands_cfg
   byte_bt j = 0;
   if (island_cfg.safed.enable) begin ret.safed = i; i++;
   end else begin ret.safed = MaxExtAxiMst + j; j++; end
-  if (island_cfg.secured.enable) begin ret.secured = i; i++;
-  end else begin ret.secured = MaxExtAxiMst + j; j++; end
+  if (island_cfg.secured.enable) begin ret.secured = i; ret.secured_idma = i+1; i+=2;
+  end else begin ret.secured = MaxExtAxiMst + j; ret.secured_idma = MaxExtAxiMst + j + 1; j+=2; end
   if (island_cfg.spatz.enable) begin ret.spatz = i; i++;
   end else begin ret.spatz = MaxExtAxiMst + j; j++; end
-  if (island_cfg.secured.enable) begin ret.secured_idma = i; i++;
-  end else begin ret.secured_idma = MaxExtAxiMst + j; j++; end
   if (island_cfg.pulp.enable) begin ret.pulp = i; i++;
   end else begin ret.pulp = MaxExtAxiMst + j; j++; end
   return ret;
@@ -424,8 +420,8 @@ typedef enum byte_bt {
 typedef enum byte_bt {
   SafetyIslandMstIdx       = CarfieldMstIdx.safed,
   SecurityIslandTlulMstIdx = CarfieldMstIdx.secured,
-  FPClusterMstIdx          = CarfieldMstIdx.spatz,
   SecurityIslandiDMAMstIdx = CarfieldMstIdx.secured_idma,
+  FPClusterMstIdx          = CarfieldMstIdx.spatz,
   IntClusterMstIdx         = CarfieldMstIdx.pulp
 } axi_mst_idx_t;
 

--- a/hw/configs/carfield_l2dual_secure_pulp_periph_can.sv
+++ b/hw/configs/carfield_l2dual_secure_pulp_periph_can.sv
@@ -1,0 +1,87 @@
+// Copyright 2022 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Yvan Tortorella <yvan.tortorella@unibo.it>
+
+package carfield_configuration;
+
+import cheshire_pkg::*;
+/*********************
+ * AXI Configuration *
+ ********************/
+//L2, port 0
+localparam bit     L2Port0Enable = 1;
+localparam doub_bt L2Port0Base = 'h78000000;
+localparam doub_bt L2Port0Size = 'h00200000;
+// L2, port 1
+localparam bit     L2Port1Enable = 1;
+localparam doub_bt L2Port1Base = L2Port0Base + L2Port0Size;
+localparam doub_bt L2Port1Size = L2Port0Size;
+// Safety Island
+localparam bit     SafetyIslandEnable = 0;
+localparam doub_bt SafetyIslandBase = 'h60000000;
+localparam doub_bt SafetyIslandSize = 'h00800000;
+// Ethernet
+localparam bit     EthernetEnable = 0;
+localparam doub_bt EthernetBase = 'h20000000;
+localparam doub_bt EthernetSize = 'h00001000;
+// Peripherals
+localparam bit     PeriphEnable = 1;
+localparam doub_bt PeriphBase = 'h20001000;
+localparam doub_bt PeriphSize = 'h00009000;
+// Spatz cluster
+localparam bit     SpatzClusterEnable = 0;
+localparam doub_bt SpatzClusterBase = 'h51000000;
+localparam doub_bt SpatzClusterSize = 'h00800000;
+// PULP cluster
+localparam bit     PulpClusterEnable = 1;
+localparam doub_bt PulpClusterBase = 'h50000000;
+localparam doub_bt PulpClusterSize = 'h00800000;
+// Security Island
+localparam bit     SecurityIslandEnable = 1;
+localparam doub_bt SecurityIslandBase = 'h0;
+localparam doub_bt SecurityIslandSize = 'h0;
+// Mailbox
+localparam bit     MailboxEnable = 1;
+localparam doub_bt MailboxBase = 'h40000000;
+localparam doub_bt MailboxSize = 'h00001000;
+/*********************
+ * APB Configuration *
+ ********************/
+// Can
+localparam bit CanEnable = 1;
+localparam doub_bt CanBase = 'h20001000;
+localparam doub_bt CanSize = 'h00001000;
+// System Timer
+localparam doub_bt SystemTimerBase = 'h20004000;
+localparam doub_bt SystemTimerSize = 'h00001000;
+// System Advanced Timer
+localparam doub_bt SystemAdvancedTimerBase = 'h20005000;
+localparam doub_bt SystemAdvancedTimerSize = 'h00001000;
+// System Watchdog
+localparam doub_bt SystemWatchdogBase = 'h20007000;
+localparam doub_bt SystemWatchdogSize = 'h00001000;
+// Hyperbus Config
+localparam doub_bt HyperBusBase = 'h20009000;
+localparam doub_bt HyperBusSize = 'h00001000;
+/************************
+ * RegBus Configuration *
+ ***********************/
+// Platform control registers
+localparam doub_bt PcrsBase = 'h20010000;
+localparam doub_bt PcrsSize = 'h00001000;
+// PLL
+localparam bit     PllCfgEnable = 1;
+localparam doub_bt PllCfgBase = 'h20020000;
+localparam doub_bt PllCfgSize = 'h00001000;
+// Padframe
+localparam bit     PadframeCfgEnable = 1;
+localparam doub_bt PadframeCfgBase = 'h200A0000;
+localparam doub_bt PadframeCfgSize = 'h00001000;
+// L2 ECC
+localparam bit     L2EccCfgEnable = 1;
+localparam doub_bt L2EccCfgBase = 'h200B0000;
+localparam doub_bt L2EccCfgSize = 'h00001000;
+
+endpackage

--- a/hw/configs/carfield_secure_pulp_periph_can.sv
+++ b/hw/configs/carfield_secure_pulp_periph_can.sv
@@ -1,0 +1,87 @@
+// Copyright 2022 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Yvan Tortorella <yvan.tortorella@unibo.it>
+
+package carfield_configuration;
+
+import cheshire_pkg::*;
+/*********************
+ * AXI Configuration *
+ ********************/
+//L2, port 0
+localparam bit     L2Port0Enable = 0;
+localparam doub_bt L2Port0Base = 'h78000000;
+localparam doub_bt L2Port0Size = 'h00200000;
+// L2, port 1
+localparam bit     L2Port1Enable = 0;
+localparam doub_bt L2Port1Base = L2Port0Base + L2Port0Size;
+localparam doub_bt L2Port1Size = L2Port0Size;
+// Safety Island
+localparam bit     SafetyIslandEnable = 0;
+localparam doub_bt SafetyIslandBase = 'h60000000;
+localparam doub_bt SafetyIslandSize = 'h00800000;
+// Ethernet
+localparam bit     EthernetEnable = 0;
+localparam doub_bt EthernetBase = 'h20000000;
+localparam doub_bt EthernetSize = 'h00001000;
+// Peripherals
+localparam bit     PeriphEnable = 1;
+localparam doub_bt PeriphBase = 'h20001000;
+localparam doub_bt PeriphSize = 'h00009000;
+// Spatz cluster
+localparam bit     SpatzClusterEnable = 0;
+localparam doub_bt SpatzClusterBase = 'h51000000;
+localparam doub_bt SpatzClusterSize = 'h00800000;
+// PULP cluster
+localparam bit     PulpClusterEnable = 1;
+localparam doub_bt PulpClusterBase = 'h50000000;
+localparam doub_bt PulpClusterSize = 'h00800000;
+// Security Island
+localparam bit     SecurityIslandEnable = 1;
+localparam doub_bt SecurityIslandBase = 'h0;
+localparam doub_bt SecurityIslandSize = 'h0;
+// Mailbox
+localparam bit     MailboxEnable = 1;
+localparam doub_bt MailboxBase = 'h40000000;
+localparam doub_bt MailboxSize = 'h00001000;
+/*********************
+ * APB Configuration *
+ ********************/
+// Can
+localparam bit CanEnable = 1;
+localparam doub_bt CanBase = 'h20001000;
+localparam doub_bt CanSize = 'h00001000;
+// System Timer
+localparam doub_bt SystemTimerBase = 'h20004000;
+localparam doub_bt SystemTimerSize = 'h00001000;
+// System Advanced Timer
+localparam doub_bt SystemAdvancedTimerBase = 'h20005000;
+localparam doub_bt SystemAdvancedTimerSize = 'h00001000;
+// System Watchdog
+localparam doub_bt SystemWatchdogBase = 'h20007000;
+localparam doub_bt SystemWatchdogSize = 'h00001000;
+// Hyperbus Config
+localparam doub_bt HyperBusBase = 'h20009000;
+localparam doub_bt HyperBusSize = 'h00001000;
+/************************
+ * RegBus Configuration *
+ ***********************/
+// Platform control registers
+localparam doub_bt PcrsBase = 'h20010000;
+localparam doub_bt PcrsSize = 'h00001000;
+// PLL
+localparam bit     PllCfgEnable = 1;
+localparam doub_bt PllCfgBase = 'h20020000;
+localparam doub_bt PllCfgSize = 'h00001000;
+// Padframe
+localparam bit     PadframeCfgEnable = 1;
+localparam doub_bt PadframeCfgBase = 'h200A0000;
+localparam doub_bt PadframeCfgSize = 'h00001000;
+// L2 ECC
+localparam bit     L2EccCfgEnable = 0;
+localparam doub_bt L2EccCfgBase = 'h200B0000;
+localparam doub_bt L2EccCfgSize = 'h00001000;
+
+endpackage

--- a/sw/sw.mk
+++ b/sw/sw.mk
@@ -61,9 +61,11 @@ CAR_ELFLOAD_BLOCKING_SAFED_SRC_C := $(CAR_SW_DIR)/tests/bare-metal/hostd/safed_o
 CAR_ELFLOAD_BLOCKING_SAFED_PATH := $(basename $(CAR_ELFLOAD_BLOCKING_SAFED_SRC_C))
 CAR_ELFLOAD_BLOCKING_PULPD_SRC_C := $(CAR_SW_DIR)/tests/bare-metal/hostd/pulpd_offloader_blocking.c
 CAR_ELFLOAD_BLOCKING_PULPD_PATH := $(basename $(CAR_ELFLOAD_BLOCKING_PULPD_SRC_C))
+CAR_ELFLOAD_PULPD_INTF_SRC_C := $(CAR_SW_DIR)/tests/bare-metal/hostd/pulp-offload-intf.c
+CAR_ELFLOAD_PULPD_INTF_PATH := $(basename $(CAR_ELFLOAD_PULPD_INTF_SRC_C))
 
 CAR_SW_TEST_SRCS_S	= $(wildcard $(CAR_SW_DIR)/tests/bare-metal/hostd/*.S)
-CAR_SW_TEST_SRCS_C	= $(filter-out $(CAR_ELFLOAD_BLOCKING_SAFED_SRC_C) $(CAR_ELFLOAD_BLOCKING_PULPD_SRC_C), $(wildcard $(CAR_SW_DIR)/tests/bare-metal/hostd/*.c))
+CAR_SW_TEST_SRCS_C	= $(filter-out $(CAR_ELFLOAD_BLOCKING_SAFED_SRC_C) $(CAR_ELFLOAD_BLOCKING_PULPD_SRC_C) $(CAR_ELFLOAD_PULPD_INTF_SRC_C), $(wildcard $(CAR_SW_DIR)/tests/bare-metal/hostd/*.c))
 
 CAR_SW_TEST_DRAM_DUMP	= $(CAR_SW_TEST_SRCS_S:.S=.car.dram.dump) $(CAR_SW_TEST_SRCS_C:.c=.car.dram.dump)
 CAR_SW_TEST_DRAM_SLM	= $(CAR_SW_TEST_SRCS_S:.S=.car.dram.slm)  $(CAR_SW_TEST_SRCS_C:.c=.car.dram.slm)
@@ -104,6 +106,7 @@ include $(CAR_SW_DIR)/tests/bare-metal/pulpd/sw.mk
 
 car-pulpd-sw-offload-tests:
 	$(call offload_tests_template,$(PULPD_HEADER_TARGETS),pulpd,$(CAR_ELFLOAD_BLOCKING_PULPD_SRC_C),$(CAR_ELFLOAD_BLOCKING_PULPD_PATH))
+	$(call offload_tests_template,$(PULPD_HEADER_TARGETS),pulpd,$(CAR_ELFLOAD_PULPD_INTF_SRC_C),$(CAR_ELFLOAD_PULPD_INTF_PATH))
 
 # Litmus tests
 LITMUS_REPO := https://github.com/pulp-platform/CHERI-Litmus.git

--- a/sw/sw.mk
+++ b/sw/sw.mk
@@ -20,8 +20,12 @@ car-sw-all: car-sw-libs car-sw-tests
 .PHONY: car-sw-all car-sw-libs car-sw-headers car-sw-tests
 
 # Libraries
-CAR_PULPD_BARE    ?= $(CAR_SW_DIR)/tests/bare-metal/pulpd
-CAR_SW_INCLUDES    = -I$(CAR_SW_DIR)/include -I$(CAR_SW_DIR)/tests/bare-metal/safed -I$(CAR_PULPD_BARE) -I$(CHS_SW_DIR)/include $(CHS_SW_DEPS_INCS)
+ifeq ($(shell echo $(PULPD_PRESENT)), 1)
+CAR_PULPD_BARE ?= -I$(CAR_SW_DIR)/tests/bare-metal/pulpd
+CAR_PULPD_SW_OFFLOAD_TESTS := car-pulpd-sw-offload-tests
+endif
+
+CAR_SW_INCLUDES    = -I$(CAR_SW_DIR)/include -I$(CAR_SW_DIR)/tests/bare-metal/safed $(CAR_PULPD_BARE) -I$(CHS_SW_DIR)/include $(CHS_SW_DEPS_INCS)
 CAR_SW_LIB_SRCS_S  = $(wildcard $(CAR_SW_DIR)/lib/*.S $(CAR_SW_DIR)/lib/**/*.S)
 CAR_SW_LIB_SRCS_C  = $(wildcard $(CAR_SW_DIR)/lib/*.c $(CAR_SW_DIR)/lib/**/*.c)
 CAR_SW_LIB_SRCS_O  = $(CAR_SW_DEPS_SRCS:.c=.o) $(CAR_SW_LIB_SRCS_S:.S=.o) $(CAR_SW_LIB_SRCS_C:.c=.o)
@@ -74,7 +78,7 @@ CAR_SW_TEST_L2_DUMP	= $(CAR_SW_TEST_SRCS_S:.S=.car.l2.dump)   $(CAR_SW_TEST_SRCS
 CAR_SW_TEST_SPM_ROMH	= $(CAR_SW_TEST_SRCS_S:.S=.car.rom.memh)  $(CAR_SW_TEST_SRCS_C:.c=.car.rom.memh)
 CAR_SW_TEST_SPM_GPTH	= $(CAR_SW_TEST_SRCS_S:.S=.car.gpt.memh)  $(CAR_SW_TEST_SRCS_C:.c=.car.gpt.memh)
 
-car-sw-tests: $(CAR_SW_TEST_DRAM_DUMP) $(CAR_SW_TEST_SPM_DUMP) $(CAR_SW_TEST_L2_DUMP) $(CAR_SW_TEST_DRAM_SLM) $(CAR_SW_TEST_SPM_ROMH) $(CAR_SW_TEST_SPM_GPTH) car-pulpd-sw-offload-tests car-safed-sw-offload-tests mibench-automotive
+car-sw-tests: $(CAR_SW_TEST_DRAM_DUMP) $(CAR_SW_TEST_SPM_DUMP) $(CAR_SW_TEST_L2_DUMP) $(CAR_SW_TEST_DRAM_SLM) $(CAR_SW_TEST_SPM_ROMH) $(CAR_SW_TEST_SPM_GPTH) $(CAR_PULPD_SW_OFFLOAD_TESTS) car-safed-sw-offload-tests mibench-automotive
 
 # Generate .slm files from elf binaries. Only used when linking against external dram
 %.car.dram.slm: %.car.dram.elf
@@ -102,11 +106,14 @@ car-safed-sw-offload-tests:
 	$(call offload_tests_template,$(SAFED_HEADER_TARGETS),safed,$(CAR_ELFLOAD_BLOCKING_SAFED_SRC_C),$(CAR_ELFLOAD_BLOCKING_SAFED_PATH))
 
 # Integer Cluster offload tests
+ifeq ($(shell echo $(PULPD_PRESENT)), 1)
 include $(CAR_SW_DIR)/tests/bare-metal/pulpd/sw.mk
 
 car-pulpd-sw-offload-tests:
 	$(call offload_tests_template,$(PULPD_HEADER_TARGETS),pulpd,$(CAR_ELFLOAD_BLOCKING_PULPD_SRC_C),$(CAR_ELFLOAD_BLOCKING_PULPD_PATH))
 	$(call offload_tests_template,$(PULPD_HEADER_TARGETS),pulpd,$(CAR_ELFLOAD_PULPD_INTF_SRC_C),$(CAR_ELFLOAD_PULPD_INTF_PATH))
+
+endif
 
 # Litmus tests
 LITMUS_REPO := https://github.com/pulp-platform/CHERI-Litmus.git

--- a/sw/sw.mk
+++ b/sw/sw.mk
@@ -25,7 +25,12 @@ CAR_PULPD_BARE ?= -I$(CAR_SW_DIR)/tests/bare-metal/pulpd
 CAR_PULPD_SW_OFFLOAD_TESTS := car-pulpd-sw-offload-tests
 endif
 
-CAR_SW_INCLUDES    = -I$(CAR_SW_DIR)/include -I$(CAR_SW_DIR)/tests/bare-metal/safed $(CAR_PULPD_BARE) -I$(CHS_SW_DIR)/include $(CHS_SW_DEPS_INCS)
+ifeq ($(shell echo $(SAFED_PRESENT)), 1)
+CAR_SAFED_BARE ?= -I$(CAR_SW_DIR)/tests/bare-metal/safed
+CAR_SAFED_SW_OFFLOAD_TESTS := car-safed-sw-offload-tests
+endif
+
+CAR_SW_INCLUDES    = -I$(CAR_SW_DIR)/include $(CAR_SAFED_BARE) $(CAR_PULPD_BARE) -I$(CHS_SW_DIR)/include $(CHS_SW_DEPS_INCS)
 CAR_SW_LIB_SRCS_S  = $(wildcard $(CAR_SW_DIR)/lib/*.S $(CAR_SW_DIR)/lib/**/*.S)
 CAR_SW_LIB_SRCS_C  = $(wildcard $(CAR_SW_DIR)/lib/*.c $(CAR_SW_DIR)/lib/**/*.c)
 CAR_SW_LIB_SRCS_O  = $(CAR_SW_DEPS_SRCS:.c=.o) $(CAR_SW_LIB_SRCS_S:.S=.o) $(CAR_SW_LIB_SRCS_C:.c=.o)
@@ -78,7 +83,7 @@ CAR_SW_TEST_L2_DUMP	= $(CAR_SW_TEST_SRCS_S:.S=.car.l2.dump)   $(CAR_SW_TEST_SRCS
 CAR_SW_TEST_SPM_ROMH	= $(CAR_SW_TEST_SRCS_S:.S=.car.rom.memh)  $(CAR_SW_TEST_SRCS_C:.c=.car.rom.memh)
 CAR_SW_TEST_SPM_GPTH	= $(CAR_SW_TEST_SRCS_S:.S=.car.gpt.memh)  $(CAR_SW_TEST_SRCS_C:.c=.car.gpt.memh)
 
-car-sw-tests: $(CAR_SW_TEST_DRAM_DUMP) $(CAR_SW_TEST_SPM_DUMP) $(CAR_SW_TEST_L2_DUMP) $(CAR_SW_TEST_DRAM_SLM) $(CAR_SW_TEST_SPM_ROMH) $(CAR_SW_TEST_SPM_GPTH) $(CAR_PULPD_SW_OFFLOAD_TESTS) car-safed-sw-offload-tests mibench-automotive
+car-sw-tests: $(CAR_SW_TEST_DRAM_DUMP) $(CAR_SW_TEST_SPM_DUMP) $(CAR_SW_TEST_L2_DUMP) $(CAR_SW_TEST_DRAM_SLM) $(CAR_SW_TEST_SPM_ROMH) $(CAR_SW_TEST_SPM_GPTH) $(CAR_PULPD_SW_OFFLOAD_TESTS) $(CAR_SAFED_SW_OFFLOAD_TESTS) mibench-automotive
 
 # Generate .slm files from elf binaries. Only used when linking against external dram
 %.car.dram.slm: %.car.dram.elf
@@ -100,10 +105,12 @@ define offload_tests_template
 endef
 
 # Safety Island offload tests
+ifeq ($(shell echo $(SAFED_PRESENT)), 1)
 include $(CAR_SW_DIR)/tests/bare-metal/safed/sw.mk
 
 car-safed-sw-offload-tests:
 	$(call offload_tests_template,$(SAFED_HEADER_TARGETS),safed,$(CAR_ELFLOAD_BLOCKING_SAFED_SRC_C),$(CAR_ELFLOAD_BLOCKING_SAFED_PATH))
+endif
 
 # Integer Cluster offload tests
 ifeq ($(shell echo $(PULPD_PRESENT)), 1)

--- a/sw/tests/bare-metal/hostd/addressability_test.c
+++ b/sw/tests/bare-metal/hostd/addressability_test.c
@@ -144,13 +144,13 @@ int main(void) {
 
     // Init the HW
     // Safety Island
-    car_enable_domain(CAR_SAFETY_RST);
+    // car_enable_domain(CAR_SAFETY_RST);
 
     // PULP Island
     car_enable_domain(CAR_PULP_RST);
 
     // Spatz Island
-    car_enable_domain(CAR_SPATZ_RST);
+    // car_enable_domain(CAR_SPATZ_RST);
 
     int errors = 0;
 
@@ -158,27 +158,27 @@ int main(void) {
     // (wrwr)
 
     // L2 shared memory
-    errors += probe_range_lfsr_wrwr((uint64_t *)CAR_L2_SPM_PORT1_INTERLEAVED_BASE_ADDR(car_l2_intl_1),
-                                    (uint64_t *)CAR_L2_SPM_PORT1_INTERLEAVED_END_ADDR(car_l2_intl_1), N_SAMPLES);
-    if (errors) {
-        char str[] = "1\n";
-        diyprintf(str, sizeof(str));
-    }
+    // errors += probe_range_lfsr_wrwr((uint64_t *)CAR_L2_SPM_PORT1_INTERLEAVED_BASE_ADDR(car_l2_intl_1),
+    //                                 (uint64_t *)CAR_L2_SPM_PORT1_INTERLEAVED_END_ADDR(car_l2_intl_1), N_SAMPLES);
+    // if (errors) {
+    //     char str[] = "1\n";
+    //     diyprintf(str, sizeof(str));
+    // }
 
-    errors += probe_range_lfsr_wrwr((uint64_t *)CAR_L2_SPM_PORT1_CONTIGUOUS_BASE_ADDR(car_l2_cont_1),
-                                    (uint64_t *)CAR_L2_SPM_PORT1_CONTIGUOUS_END_ADDR(car_l2_cont_1), N_SAMPLES);
-    if (errors) {
-        char str[] = "2\n";
-        diyprintf(str, sizeof(str));
-    }
+    // errors += probe_range_lfsr_wrwr((uint64_t *)CAR_L2_SPM_PORT1_CONTIGUOUS_BASE_ADDR(car_l2_cont_1),
+    //                                 (uint64_t *)CAR_L2_SPM_PORT1_CONTIGUOUS_END_ADDR(car_l2_cont_1), N_SAMPLES);
+    // if (errors) {
+    //     char str[] = "2\n";
+    //     diyprintf(str, sizeof(str));
+    // }
 
     // Safety Island
-    errors += probe_range_lfsr_wrwr((uint64_t *)CAR_SAFETY_ISLAND_SPM_BASE_ADDR(car_safety_island),
-                                    (uint64_t *)CAR_SAFETY_ISLAND_SPM_END_ADDR(car_safety_island), N_SAMPLES);
-    if (errors) {
-        char str[] = "3\n";
-        diyprintf(str, sizeof(str));
-    }
+    // errors += probe_range_lfsr_wrwr((uint64_t *)CAR_SAFETY_ISLAND_SPM_BASE_ADDR(car_safety_island),
+    //                                 (uint64_t *)CAR_SAFETY_ISLAND_SPM_END_ADDR(car_safety_island), N_SAMPLES);
+    // if (errors) {
+    //     char str[] = "3\n";
+    //     diyprintf(str, sizeof(str));
+    // }
     // Integer Cluster
     errors += probe_range_lfsr_wrwr((uint64_t *)CAR_INT_CLUSTER_SPM_BASE_ADDR(car_integer_cluster), (uint64_t *)CAR_INT_CLUSTER_SPM_END_ADDR(car_integer_cluster),
                                     N_SAMPLES);
@@ -193,38 +193,38 @@ int main(void) {
         diyprintf(str, sizeof(str));
     }
     // FP Cluster
-    errors += probe_range_lfsr_wrwr((uint64_t *)CAR_FP_CLUSTER_SPM_BASE_ADDR(car_spatz_cluster), (uint64_t *)CAR_FP_CLUSTER_SPM_END_ADDR(car_spatz_cluster),
-                                    N_SAMPLES);
-    if (errors) {
-        char str[] = "6\n";
-        diyprintf(str, sizeof(str));
-    }
+    // errors += probe_range_lfsr_wrwr((uint64_t *)CAR_FP_CLUSTER_SPM_BASE_ADDR(car_spatz_cluster), (uint64_t *)CAR_FP_CLUSTER_SPM_END_ADDR(car_spatz_cluster),
+    //                                 N_SAMPLES);
+    // if (errors) {
+    //     char str[] = "6\n";
+    //     diyprintf(str, sizeof(str));
+    // }
     // TODO Mailboxes
 
     // Probe an address space with pseudo-random values and read all after
     // writing (wwrr)
 
     // L2 shared memory
-    errors += probe_range_lfsr_wwrr((uint64_t *)CAR_L2_SPM_PORT1_INTERLEAVED_BASE_ADDR(car_l2_intl_1),
-                                    (uint64_t *)CAR_L2_SPM_PORT1_INTERLEAVED_END_ADDR(car_l2_intl_1), N_SAMPLES);
-    if (errors) {
-        char str[] = "7\n";
-        diyprintf(str, sizeof(str));
-    }
-    errors += probe_range_lfsr_wwrr((uint64_t *)CAR_L2_SPM_PORT1_CONTIGUOUS_BASE_ADDR(car_l2_cont_1),
-                                    (uint64_t *)CAR_L2_SPM_PORT1_CONTIGUOUS_END_ADDR(car_l2_cont_1), N_SAMPLES);
-    if (errors) {
-        char str[] = "8\n";
-        diyprintf(str, sizeof(str));
-    }
+    // errors += probe_range_lfsr_wwrr((uint64_t *)CAR_L2_SPM_PORT1_INTERLEAVED_BASE_ADDR(car_l2_intl_1),
+    //                                 (uint64_t *)CAR_L2_SPM_PORT1_INTERLEAVED_END_ADDR(car_l2_intl_1), N_SAMPLES);
+    // if (errors) {
+    //     char str[] = "7\n";
+    //     diyprintf(str, sizeof(str));
+    // }
+    // errors += probe_range_lfsr_wwrr((uint64_t *)CAR_L2_SPM_PORT1_CONTIGUOUS_BASE_ADDR(car_l2_cont_1),
+    //                                 (uint64_t *)CAR_L2_SPM_PORT1_CONTIGUOUS_END_ADDR(car_l2_cont_1), N_SAMPLES);
+    // if (errors) {
+    //     char str[] = "8\n";
+    //     diyprintf(str, sizeof(str));
+    // }
 
     // Safety Island
-    errors += probe_range_lfsr_wwrr((uint64_t *)CAR_SAFETY_ISLAND_SPM_BASE_ADDR(car_safety_island),
-                                    (uint64_t *)CAR_SAFETY_ISLAND_SPM_END_ADDR(car_safety_island), N_SAMPLES);
-    if (errors) {
-        char str[] = "9\n";
-        diyprintf(str, sizeof(str));
-    }
+    // errors += probe_range_lfsr_wwrr((uint64_t *)CAR_SAFETY_ISLAND_SPM_BASE_ADDR(car_safety_island),
+    //                                 (uint64_t *)CAR_SAFETY_ISLAND_SPM_END_ADDR(car_safety_island), N_SAMPLES);
+    // if (errors) {
+    //     char str[] = "9\n";
+    //     diyprintf(str, sizeof(str));
+    // }
     // Integer Cluster
     errors += probe_range_lfsr_wwrr((uint64_t *)CAR_INT_CLUSTER_SPM_BASE_ADDR(car_integer_cluster), (uint64_t *)CAR_INT_CLUSTER_SPM_END_ADDR(car_integer_cluster),
                                     N_SAMPLES);
@@ -239,12 +239,12 @@ int main(void) {
         diyprintf(str, sizeof(str));
     }
     // FP Cluster
-    errors += probe_range_lfsr_wrwr((uint64_t *)CAR_FP_CLUSTER_SPM_BASE_ADDR(car_spatz_cluster), (uint64_t *)CAR_FP_CLUSTER_SPM_END_ADDR(car_spatz_cluster),
-                                    N_SAMPLES);
-    if (errors) {
-        char str[] = "c\n";
-        diyprintf(str, sizeof(str));
-    }
+    // errors += probe_range_lfsr_wrwr((uint64_t *)CAR_FP_CLUSTER_SPM_BASE_ADDR(car_spatz_cluster), (uint64_t *)CAR_FP_CLUSTER_SPM_END_ADDR(car_spatz_cluster),
+    //                                 N_SAMPLES);
+    // if (errors) {
+    //     char str[] = "c\n";
+    //     diyprintf(str, sizeof(str));
+    // }
     // TODO Mailboxes
 
     return errors;

--- a/sw/tests/bare-metal/hostd/pulp-offload-intf.c
+++ b/sw/tests/bare-metal/hostd/pulp-offload-intf.c
@@ -1,0 +1,120 @@
+// Copyright 2023 ETH Zurich and University of Bologna.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Luca Valente <luca.valente@unibo.it>
+//
+// Bare-metal offload test for the PULP cluster with interference
+
+#include <stdio.h>
+#include <stdint.h>
+
+#include "car_memory_map.h"
+#include "car_util.h"
+#include "dif/clint.h"
+#include "dif/uart.h"
+#include "params.h"
+#include "regs/cheshire.h"
+#include "csr.h"
+#include "util.h"
+#include "payload.h"
+#include "printf.h"
+
+#define LCL
+
+long int buffer[128];
+
+void read_from_cache(int l1_way_size, int stride) {
+    asm volatile("": : :"memory");
+    for(volatile int j = 0; j < l1_way_size; j++)
+    {
+      * ( ( volatile long int * ) &buffer[j] );
+    }
+    asm volatile("": : :"memory");
+    for(volatile int j = 0; j < l1_way_size; j++)
+    {
+      * ( ( volatile long int * ) &buffer[j*stride]);
+    }
+    asm volatile("": : :"memory");
+}
+
+long unsigned sweep(int stride)
+{
+
+  int l1_way_size = 4 * 1024 / 8;
+  int working_set = l1_way_size * stride * 8;
+
+  volatile long unsigned cycle_start;
+
+  for(int i = 0; i < 10; i++)
+  {
+    if(i==1)
+    {
+      cycle_start = get_mcycle();
+    }
+    read_from_cache(l1_way_size, stride);
+  }
+
+  volatile long unsigned cycles = get_mcycle() - cycle_start;
+
+  #ifdef VERBOSE
+  printf("%3dKB        , %6d     \r\n",
+           working_set / 1024, (int)cycles);
+  #endif
+
+  return cycles;
+}
+
+int main(void)
+{
+  // Set the LLC as LLC
+  axi_llc_reg32_all_cache(&__base_llc);
+  writew(0x18,CAR_HYPERBUS_CFG_BASE_ADDR+0x18);
+  volatile uint32_t pulp_ret_val = 0;
+  // Init the HW
+  // PULP Island
+  #ifdef LCL
+  car_enable_domain(CAR_PULP_RST);
+  char str[] = "Cluster boot.\r\n";
+  uint32_t rtc_freq = *reg32(&__base_regs, CHESHIRE_RTC_FREQ_REG_OFFSET);
+  uint64_t reset_freq = clint_get_core_freq(rtc_freq, 2500);
+
+  load_binary();
+
+  volatile uint32_t pulp_boot_default = ELF_BOOT_ADDR;
+
+  pulp_cluster_set_bootaddress(pulp_boot_default);
+
+  uart_init(&__base_uart, reset_freq, 115200);
+  uart_write_str(&__base_uart, str, sizeof(str));
+  uart_write_flush(&__base_uart);
+
+  pulp_cluster_start();
+  #endif
+
+  #ifdef VERBOSE
+  printf("Buffer: %x\n", buffer);
+  #endif
+
+  volatile long unsigned cycles[5];
+  int j=0;
+  for( int i = 4; i<128; i=i*2){
+    cycles[j] = sweep(i);
+    j++;
+  }
+
+  #ifdef LCL
+  pulp_cluster_wait_eoc();
+
+  pulp_ret_val = pulp_cluster_get_return();
+  #endif
+
+
+  for(int i=0;i<5;i++)
+    printf("%d\r\n",cycles[i]);
+
+  printf("Done\n");
+
+  return pulp_ret_val;
+
+}

--- a/sw/tests/bare-metal/hostd/pulpd_offloader_blocking.c
+++ b/sw/tests/bare-metal/hostd/pulpd_offloader_blocking.c
@@ -35,6 +35,7 @@ int main(void)
   load_binary();
 
   volatile uint32_t pulp_boot_default = 0x10008080;
+  volatile uint32_t pulp_boot_default = ELF_BOOT_ADDR;
   volatile uint32_t pulp_ret_val = 0;
 
   pulp_cluster_set_bootaddress(pulp_boot_default);

--- a/sw/tests/bare-metal/hostd/pulpd_offloader_blocking.c
+++ b/sw/tests/bare-metal/hostd/pulpd_offloader_blocking.c
@@ -34,7 +34,6 @@ int main(void)
 
   load_binary();
 
-  volatile uint32_t pulp_boot_default = 0x10008080;
   volatile uint32_t pulp_boot_default = ELF_BOOT_ADDR;
   volatile uint32_t pulp_ret_val = 0;
 

--- a/sw/tests/bare-metal/hostd/pulpd_offloader_blocking.c
+++ b/sw/tests/bare-metal/hostd/pulpd_offloader_blocking.c
@@ -34,7 +34,7 @@ int main(void)
 
   load_binary();
 
-  volatile uint32_t pulp_boot_default = 0x78008080;
+  volatile uint32_t pulp_boot_default = 0x10008080;
   volatile uint32_t pulp_ret_val = 0;
 
   pulp_cluster_set_bootaddress(pulp_boot_default);

--- a/sw/tests/bare-metal/hostd/sw_rst_seq.c
+++ b/sw/tests/bare-metal/hostd/sw_rst_seq.c
@@ -24,7 +24,7 @@ int main(void)
     if (hart_id() != 0) wfi();
 
     // Safety Island
-    car_enable_domain(CAR_SAFETY_RST);
+    // car_enable_domain(CAR_SAFETY_RST);
 
     // Security Island
 //    car_enable_domain(CAR_SECURITY_RST);
@@ -33,7 +33,7 @@ int main(void)
     car_enable_domain(CAR_PULP_RST);
 
     // Spatz Island
-    car_enable_domain(CAR_SPATZ_RST);
+    // car_enable_domain(CAR_SPATZ_RST);
 
     // Safety Island
 
@@ -43,49 +43,49 @@ int main(void)
     uint64_t magic = 0xcafebeef;
 
     // Write a pattern to safety island boot addr
-    writew(magic, CAR_SAFETY_ISLAND_PERIPHS_BASE_ADDR(car_safety_island) +
-		      SAFETY_SOC_CTRL_BOOTADDR_REG_OFFSET);
+    // writew(magic, CAR_SAFETY_ISLAND_PERIPHS_BASE_ADDR(car_safety_island) +
+		//       SAFETY_SOC_CTRL_BOOTADDR_REG_OFFSET);
 
     // Double check
-    if (readw(CAR_SAFETY_ISLAND_PERIPHS_BASE_ADDR(car_safety_island) +
-	      SAFETY_SOC_CTRL_BOOTADDR_REG_OFFSET) != magic)
-	return ESAFEDNOACCES;
+    // if (readw(CAR_SAFETY_ISLAND_PERIPHS_BASE_ADDR(car_safety_island) +
+	  //     SAFETY_SOC_CTRL_BOOTADDR_REG_OFFSET) != magic)
+	  // return ESAFEDNOACCES;
 
     // engage reset sequence for safety island
-    car_reset_domain(CAR_SAFETY_RST);
+    // car_reset_domain(CAR_SAFETY_RST);
 
     // After the reset we should only see zeros
-    if (readw(CAR_SAFETY_ISLAND_PERIPHS_BASE_ADDR(car_safety_island) +
-	      SAFETY_SOC_CTRL_BOOTADDR_REG_OFFSET) !=
-	SAFETY_ISLAND_BOOT_ADDR_RSVAL)
-	return ESAFEDNOACCES;
+    // if (readw(CAR_SAFETY_ISLAND_PERIPHS_BASE_ADDR(car_safety_island) +
+	  //     SAFETY_SOC_CTRL_BOOTADDR_REG_OFFSET) !=
+	  //     SAFETY_ISLAND_BOOT_ADDR_RSVAL)
+	  // return ESAFEDNOACCES;
 
     // Spatz
-    writew(magic, CAR_FP_CLUSTER_PERIPHS_BASE_ADDR(car_spatz_cluster) +
-		      SPATZ_CLUSTER_PERIPHERAL_CLUSTER_BOOT_CONTROL_REG_OFFSET);
-    if (readw(CAR_FP_CLUSTER_PERIPHS_BASE_ADDR(car_spatz_cluster) +
-	      SPATZ_CLUSTER_PERIPHERAL_CLUSTER_BOOT_CONTROL_REG_OFFSET) !=
-	magic)
-	return EFPCLNOACCES;
+    // writew(magic, CAR_FP_CLUSTER_PERIPHS_BASE_ADDR(car_spatz_cluster) +
+		//       SPATZ_CLUSTER_PERIPHERAL_CLUSTER_BOOT_CONTROL_REG_OFFSET);
+    // if (readw(CAR_FP_CLUSTER_PERIPHS_BASE_ADDR(car_spatz_cluster) +
+	  //     SPATZ_CLUSTER_PERIPHERAL_CLUSTER_BOOT_CONTROL_REG_OFFSET) !=
+	  //     magic)
+	  // return EFPCLNOACCES;
 
-    car_reset_domain(CAR_SPATZ_RST);
-    if (readw(CAR_FP_CLUSTER_PERIPHS_BASE_ADDR(car_spatz_cluster) +
-	      SPATZ_CLUSTER_PERIPHERAL_CLUSTER_BOOT_CONTROL_REG_OFFSET) != 0)
-	return EFPCLNOACCES;
+    // car_reset_domain(CAR_SPATZ_RST);
+    // if (readw(CAR_FP_CLUSTER_PERIPHS_BASE_ADDR(car_spatz_cluster) +
+	  //     SPATZ_CLUSTER_PERIPHERAL_CLUSTER_BOOT_CONTROL_REG_OFFSET) != 0)
+	  // return EFPCLNOACCES;
 
     // PULP Reset
     writew(magic, CAR_INT_CLUSTER_BOOT_ADDR_REG(car_integer_cluster));
     if (readw(CAR_INT_CLUSTER_BOOT_ADDR_REG(car_integer_cluster)) != magic)
-	return EINTCLNOACCES;
+	  return EINTCLNOACCES;
 
     volatile uint32_t pulp_boot_addr_rst_value = 0x78008080;
     car_reset_domain(CAR_PULP_RST);
     if (readw(CAR_INT_CLUSTER_BOOT_ADDR_REG(car_integer_cluster)) != pulp_boot_addr_rst_value)
-	return EINTCLNOACCES;
+	  return EINTCLNOACCES;
 
     // L2 Reset
     // Memory doesn't have a reset so this needs to be checked manually
-    car_reset_domain(CAR_L2_RST);
+    // car_reset_domain(CAR_L2_RST);
 
     // Security Island
     // We can't access anything so this needs to be checked manually In secure boot mode, the

--- a/target/sim/src/carfield_tb.sv
+++ b/target/sim/src/carfield_tb.sv
@@ -285,7 +285,7 @@ module tb_carfield_soc;
   // pulp cluster standalone
   if (CarfieldIslandsCfg.pulp.enable) begin: gen_pulp_tb
     // Useful register addresses
-    localparam int unsigned CarL2StartAddr                      = 32'h7800_0000;
+    localparam int unsigned CarL2StartAddr                      = 32'h1000_0000;
     localparam int unsigned CarDramStartAddr                    = 32'h8000_0000;
     localparam int unsigned PulpdNumCores                       = 12;
     localparam int unsigned PulpdBootAddrL2                     = CarL2StartAddr + 32'h8080;


### PR DESCRIPTION
Since the HW design became highli parametric, this PR intends to reflect such parametrization also to the SW compilation and hardware initialization.
The env script containing the environment parameters for the design should also contain the export to some environment variables that define wether an island is used or not. These environment variables allow for:
* Compiling the software only for the islands that are actually used.
* Skipping the code generation of islands that are not intended to use.
Could be interesting to backport it to Carfield, @alex96295 what do you think?

This PR also alignes Cheshire so that:
* It points to a CVA6-SDK dedicated to Astral that is removing SSH link to Buildroot.
* It has a working CI.