### PR TITLE
Extend parametrization to compiled software and initialized hardware.

### DIFF
--- a/Bender.local
+++ b/Bender.local
@@ -4,7 +4,7 @@
 
 overrides:
   axi:                  { git: https://github.com/pulp-platform/axi.git                   , version: 0.39.1 }
-  axi_riscv_atomics:    { git: https://github.com/pulp-platform/axi_riscv_atomics.git     , version: 0.8.2 }
+  axi_riscv_atomics:    { git: https://github.com/pulp-platform/axi_riscv_atomics.git     , rev: 6a85f44fdb1fe93162de7241476bba81e2247cb5 } # branch: astral
   apb:                  { git: "https://github.com/pulp-platform/apb.git"                 , version: 0.2.3 }
   redundancy_cells:     { git: "https://github.com/pulp-platform/redundancy_cells.git"    , rev: "c37bdb47339bf70e8323de8df14ea8bbeafb6583" } # branch: astral-rebase
   hci:                  { git: "https://github.com/pulp-platform/hci.git"                 , rev: v1.1 }

--- a/Bender.local
+++ b/Bender.local
@@ -14,7 +14,7 @@ overrides:
   hier-icache:          { git: "https://github.com/pulp-platform/hier-icache.git"         , rev: 2886cb2a46cea3e2bd2d979b505d88fadfbe150c   } # branch: astral
   scm:                  { git: "https://github.com/pulp-platform/scm.git"                 , rev: 74426dee36f28ae1c02f7635cf844a0156145320   }
   cluster_interconnect: { git: "https://github.com/pulp-platform/cluster_interconnect.git", rev: 89e1019d64a86425211be6200770576cbdf3e8b3   } # branch: assertion-fix
-  clic:                 { git: "https://github.com/pulp-platform/clic.git"                , rev: 0ff9f07e0a492bff046dfe24399b1e1e82d557b7   } # branch: balasr/dev-2
+  clic:                 { git: "https://github.com/pulp-platform/clic.git"                , rev: 40ae266dab5768f63ca8dabe70e7474feb403bab   } # branch: critical-path
   fpnew:                { git: "https://github.com/pulp-platform/cvfpu.git"               , rev: pulp-v0.1.3 }
   cv32e40p:             { git: "https://github.com/pulp-platform/cv32e40p.git"            , rev: e863f576699815b38cc9d80dbdede8ed5efd5991   }
   axi_rt:               { git: "https://github.com/pulp-platform/axi_rt.git"              , version: =0.0.0-alpha.4                         }

--- a/Bender.lock
+++ b/Bender.lock
@@ -132,8 +132,8 @@ packages:
     - tagger
     - unbent
   clic:
-    revision: 0ff9f07e0a492bff046dfe24399b1e1e82d557b7
-    version: 3.0.0-for-carfield
+    revision: 40ae266dab5768f63ca8dabe70e7474feb403bab
+    version: null
     source:
       Git: https://github.com/pulp-platform/clic.git
     dependencies:

--- a/Bender.lock
+++ b/Bender.lock
@@ -66,8 +66,8 @@ packages:
     - common_cells
     - obi
   axi_riscv_atomics:
-    revision: 0ac3a78fe342c5a5b9b10bff49d58897f773059e
-    version: 0.8.2
+    revision: 6a85f44fdb1fe93162de7241476bba81e2247cb5
+    version: null
     source:
       Git: https://github.com/pulp-platform/axi_riscv_atomics.git
     dependencies:
@@ -106,7 +106,7 @@ packages:
       Git: https://github.com/AlSaqr-platform/can_bus.git
     dependencies: []
   cheshire:
-    revision: 6d389373df6b54c09888f89411b7e231d2430722
+    revision: fa4d7301d4e1cbe472d66a4dd8d210855e690249
     version: null
     source:
       Git: https://github.com/pulp-platform/cheshire.git
@@ -162,8 +162,8 @@ packages:
     dependencies:
     - hci
   common_cells:
-    revision: ad22699793d98ef714f120c6268fe92d096a61e1
-    version: 1.33.1
+    revision: 0d67563b6b592549542544f1abc0f43e5d4ee8b4
+    version: 1.35.0
     source:
       Git: https://github.com/pulp-platform/common_cells.git
     dependencies:

--- a/Bender.yml
+++ b/Bender.yml
@@ -71,6 +71,10 @@ sources:
     files:
       - hw/configs/carfield_l2dual_safe_pulp_spatz_periph.sv
 
+  - target: carfield_l2dual_secure_pulp_periph_can
+    files:
+      - hw/configs/carfield_l2dual_secure_pulp_periph_can.sv
+
   # Source files grouped in levels. Files in level 0 have no dependencies on files in this
   # package. Files in level 1 only depend on files in level 0, files in level 2 on files in
   # levels 1 and 0, etc. Files within a level are ordered alphabetically.

--- a/Bender.yml
+++ b/Bender.yml
@@ -13,7 +13,7 @@ package:
 dependencies:
   register_interface: { git: https://github.com/pulp-platform/register_interface.git,   version: 0.4.3                                }
   axi:                { git: https://github.com/pulp-platform/axi.git,                  version: 0.39.1                               }
-  cheshire:           { git: https://github.com/pulp-platform/cheshire.git,             rev: 6d389373df6b54c09888f89411b7e231d2430722 } # branch: astral-new
+  cheshire:           { git: https://github.com/pulp-platform/cheshire.git,             rev: fa4d7301d4e1cbe472d66a4dd8d210855e690249 } # branch: astral-new
   hyperbus:           { git: https://github.com/pulp-platform/hyperbus.git,             rev: f039e601c8b6590181734e6d26ff8b77aa380412 } # branch: chi/add_fsm_with_Tcsh
   dyn_mem:            { git: https://github.com/pulp-platform/dyn_spm.git,              rev: 480590062742230dc9bd4050358a15b4747bdf34 } # branch: main
   safety_island:      { git: https://github.com/pulp-platform/safety_island.git,        rev: aaef55c798ab53560faaf451a86668fa1e6d0f3b } # branch: carfield

--- a/bender-common.mk
+++ b/bender-common.mk
@@ -6,7 +6,7 @@
 # Author: Matteo Perotti <mperotti@iis.ee.ethz.ch>
 
 # Runtime-selectable Carfield configuration
-CARFIELD_CONFIG ?= carfield_l2dual_safe_secure_pulp_spatz_periph_can
+CARFIELD_CONFIG ?= carfield_l2dual_secure_pulp_periph_can
 
 # bender targets
 common_targs += -t cva6

--- a/bender-common.mk
+++ b/bender-common.mk
@@ -26,3 +26,20 @@ common_defs += -D PRIVATE_ICACHE
 common_defs += -D HIERARCHY_ICACHE_32BIT
 common_defs += -D ICAHE_USE_FF
 common_defs += -D CLUSTER_ALIAS
+
+# Island exclusion
+ifeq ($(shell echo $(PULPD_PRESENT)), 0)
+common_targs += -e pulp_cluster
+endif
+
+ifeq ($(shell echo $(SAFED_PRESENT)), 0)
+common_targs += -e safety_island
+endif
+
+ifeq ($(shell echo $(SPATZD_PRESENT)), 0)
+common_targs += -e spatz
+endif
+
+ifeq ($(shell echo $(SECURED_PRESENT)), 0)
+common_targs += -e opentitan
+endif

--- a/bender-common.mk
+++ b/bender-common.mk
@@ -6,7 +6,7 @@
 # Author: Matteo Perotti <mperotti@iis.ee.ethz.ch>
 
 # Runtime-selectable Carfield configuration
-CARFIELD_CONFIG ?= carfield_l2dual_secure_pulp_periph_can
+CARFIELD_CONFIG ?= carfield_l2dual_safe_secure_pulp_spatz_periph_can
 
 # bender targets
 common_targs += -t cva6

--- a/carfield.mk
+++ b/carfield.mk
@@ -156,9 +156,46 @@ car-checkout: car-checkout-deps
 ############
 # Build SW #
 ############
-include $(CAR_SW_DIR)/sw.mk
+## @section Islands compile exclusion
+ifeq ($(shell echo $(PULPD_PRESENT)), 1)
+PULPD_SW_BUILD := pulpd-sw-build
+PULPD_SW_INIT := pulpd-sw-init
+endif
+
+ifeq ($(shell echo $(SAFED_PRESENT)), 1)
+SAFED_SW_BUILD := safed-sw-build
+SAFED_SW_INIT := safed-sw-init
+endif
+
+ifeq ($(shell echo $(SAFED_PRESENT)), 1)
+SPATZD_HW_INIT := spatzd-hw-init
+endif
+
+ifeq ($(shell echo $(SECURED_PRESENT)), 1)
+SECD_HW_INIT := secd-hw-init
+endif
+
+## @section Islands compile exclusion
+ifeq ($(shell echo $(PULPD_PRESENT)), 1)
+PULPD_SW_BUILD := pulpd-sw-build
+PULPD_SW_INIT := pulpd-sw-init
+endif
+
+ifeq ($(shell echo $(SAFED_PRESENT)), 1)
+SAFED_SW_BUILD := safed-sw-build
+SAFED_SW_INIT := safed-sw-init
+endif
+
+ifeq ($(shell echo $(SPATZD_PRESENT)), 1)
+SPATZD_HW_INIT := spatzd-hw-init
+endif
+
+ifeq ($(shell echo $(SECURED_PRESENT)), 1)
+SECD_HW_INIT := secd-hw-init
+endif
 
 ## @section Carfield platform SW build
+include $(CAR_SW_DIR)/sw.mk
 .PHONY: chs-sw-build
 ## Build the host domain (Cheshire) SW libraries and generates an archive (`libcheshire.a`)
 ## available for Carfield as static library at link time.
@@ -166,7 +203,7 @@ chs-sw-build: chs-sw-all
 
 .PHONY: car-sw-build
 ## Builds carfield application SW and specific libraries. It links against `libcheshire.a`.
-car-sw-build: chs-sw-build safed-sw-build pulpd-sw-build car-sw-all
+car-sw-build: chs-sw-build $(SAFED_SW_BUILD) $(PULPD_SW_BUILD) car-sw-all
 
 .PHONY: safed-sw-init pulpd-sw-init
 ## Clone safe domain's SW stack in the dedicated repository.
@@ -214,7 +251,7 @@ pulpd-sw-build: pulpd-sw-init
 ## Initialize Carfield HW. This step takes care of the generation of the missing hardware or the
 ## update of default HW configurations in some of the domains. See the two prerequisite's comment
 ## for more information.
-car-hw-init: spatzd-hw-init chs-hw-init secd-hw-init
+car-hw-init: $(SPATZD_HW_INIT) chs-hw-init $(SECD_HW_INIT)
 
 #Build OpenTitan's debug rom with support for coreid != 0x0
 secd-hw-init:
@@ -289,7 +326,7 @@ include $(CAR_SIM_DIR)/sim.mk
 
 .PHONY: car-init-all
 ## Shortcut to initialize carfield with all the targets described above.
-car-init-all: car-checkout car-hw-init car-sim-init safed-sw-init pulpd-sw-init mibench
+car-init-all: car-checkout car-hw-init car-sim-init $(SAFED_SW_INIT) $(PULPD_SW_INIT) mibench
 
 ## Initialize Carfield and build SW
 .PHONY: car-all

--- a/carfield.mk
+++ b/carfield.mk
@@ -366,7 +366,7 @@ include $(CAR_XIL_DIR)/xilinx.mk
 mibench: $(CAR_SW_DIR)/benchmarks/mibench
 
 $(CAR_SW_DIR)/benchmarks/mibench:
-	git clone git@github.com:alex96295/mibench.git -b carfield $@
+	git clone https://github.com/alex96295/mibench.git -b carfield $@
 
 # Litmus tests
 LITMUS_WORK_DIR  := work-litmus

--- a/carfield.mk
+++ b/carfield.mk
@@ -175,25 +175,6 @@ ifeq ($(shell echo $(SECURED_PRESENT)), 1)
 SECD_HW_INIT := secd-hw-init
 endif
 
-## @section Islands compile exclusion
-ifeq ($(shell echo $(PULPD_PRESENT)), 1)
-PULPD_SW_BUILD := pulpd-sw-build
-PULPD_SW_INIT := pulpd-sw-init
-endif
-
-ifeq ($(shell echo $(SAFED_PRESENT)), 1)
-SAFED_SW_BUILD := safed-sw-build
-SAFED_SW_INIT := safed-sw-init
-endif
-
-ifeq ($(shell echo $(SPATZD_PRESENT)), 1)
-SPATZD_HW_INIT := spatzd-hw-init
-endif
-
-ifeq ($(shell echo $(SECURED_PRESENT)), 1)
-SECD_HW_INIT := secd-hw-init
-endif
-
 ## @section Carfield platform SW build
 include $(CAR_SW_DIR)/sw.mk
 .PHONY: chs-sw-build

--- a/env/env-iis.sh
+++ b/env/env-iis.sh
@@ -3,6 +3,12 @@
 # SPDX-License-Identifier: SHL-0.51
 #
 
+# Set environment variables to choose of which island we have to compile the sw
+export PULPD_PRESENT=1
+export SAFED_PRESENT=1
+export SECURED_PRESENT=1
+export SPATZD_PRESENT=1
+
 # set up environment variables for rtl simulation
 ROOTD=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/.." && pwd)
 export PATH=/usr/pack/riscv-1.0-kgf/riscv64-gcc-11.2.0/bin:$PATH # RV64 GCC toolchain

--- a/hw/configs/carfield_l2dual_secure_pulp_periph_can.sv
+++ b/hw/configs/carfield_l2dual_secure_pulp_periph_can.sv
@@ -1,0 +1,87 @@
+// Copyright 2022 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Yvan Tortorella <yvan.tortorella@unibo.it>
+
+package carfield_configuration;
+
+import cheshire_pkg::*;
+/*********************
+ * AXI Configuration *
+ ********************/
+//L2, port 0
+localparam bit     L2Port0Enable = 1;
+localparam doub_bt L2Port0Base = 'h78000000;
+localparam doub_bt L2Port0Size = 'h00200000;
+// L2, port 1
+localparam bit     L2Port1Enable = 1;
+localparam doub_bt L2Port1Base = L2Port0Base + L2Port0Size;
+localparam doub_bt L2Port1Size = L2Port0Size;
+// Safety Island
+localparam bit     SafetyIslandEnable = 0;
+localparam doub_bt SafetyIslandBase = 'h60000000;
+localparam doub_bt SafetyIslandSize = 'h00800000;
+// Ethernet
+localparam bit     EthernetEnable = 0;
+localparam doub_bt EthernetBase = 'h20000000;
+localparam doub_bt EthernetSize = 'h00001000;
+// Peripherals
+localparam bit     PeriphEnable = 1;
+localparam doub_bt PeriphBase = 'h20001000;
+localparam doub_bt PeriphSize = 'h00009000;
+// Spatz cluster
+localparam bit     SpatzClusterEnable = 0;
+localparam doub_bt SpatzClusterBase = 'h51000000;
+localparam doub_bt SpatzClusterSize = 'h00800000;
+// PULP cluster
+localparam bit     PulpClusterEnable = 1;
+localparam doub_bt PulpClusterBase = 'h50000000;
+localparam doub_bt PulpClusterSize = 'h00800000;
+// Security Island
+localparam bit     SecurityIslandEnable = 1;
+localparam doub_bt SecurityIslandBase = 'h0;
+localparam doub_bt SecurityIslandSize = 'h0;
+// Mailbox
+localparam bit     MailboxEnable = 1;
+localparam doub_bt MailboxBase = 'h40000000;
+localparam doub_bt MailboxSize = 'h00001000;
+/*********************
+ * APB Configuration *
+ ********************/
+// Can
+localparam bit CanEnable = 1;
+localparam doub_bt CanBase = 'h20001000;
+localparam doub_bt CanSize = 'h00001000;
+// System Timer
+localparam doub_bt SystemTimerBase = 'h20004000;
+localparam doub_bt SystemTimerSize = 'h00001000;
+// System Advanced Timer
+localparam doub_bt SystemAdvancedTimerBase = 'h20005000;
+localparam doub_bt SystemAdvancedTimerSize = 'h00001000;
+// System Watchdog
+localparam doub_bt SystemWatchdogBase = 'h20007000;
+localparam doub_bt SystemWatchdogSize = 'h00001000;
+// Hyperbus Config
+localparam doub_bt HyperBusBase = 'h20009000;
+localparam doub_bt HyperBusSize = 'h00001000;
+/************************
+ * RegBus Configuration *
+ ***********************/
+// Platform control registers
+localparam doub_bt PcrsBase = 'h20010000;
+localparam doub_bt PcrsSize = 'h00001000;
+// PLL
+localparam bit     PllCfgEnable = 1;
+localparam doub_bt PllCfgBase = 'h20020000;
+localparam doub_bt PllCfgSize = 'h00001000;
+// Padframe
+localparam bit     PadframeCfgEnable = 1;
+localparam doub_bt PadframeCfgBase = 'h200A0000;
+localparam doub_bt PadframeCfgSize = 'h00001000;
+// L2 ECC
+localparam bit     L2EccCfgEnable = 1;
+localparam doub_bt L2EccCfgBase = 'h200B0000;
+localparam doub_bt L2EccCfgSize = 'h00001000;
+
+endpackage

--- a/sw/sw.mk
+++ b/sw/sw.mk
@@ -20,8 +20,17 @@ car-sw-all: car-sw-libs car-sw-tests
 .PHONY: car-sw-all car-sw-libs car-sw-headers car-sw-tests
 
 # Libraries
-CAR_PULPD_BARE    ?= $(CAR_SW_DIR)/tests/bare-metal/pulpd
-CAR_SW_INCLUDES    = -I$(CAR_SW_DIR)/include -I$(CAR_SW_DIR)/tests/bare-metal/safed -I$(CAR_PULPD_BARE) -I$(CHS_SW_DIR)/include $(CHS_SW_DEPS_INCS)
+ifeq ($(shell echo $(PULPD_PRESENT)), 1)
+CAR_PULPD_BARE ?= -I$(CAR_SW_DIR)/tests/bare-metal/pulpd
+CAR_PULPD_SW_OFFLOAD_TESTS := car-pulpd-sw-offload-tests
+endif
+
+ifeq ($(shell echo $(SAFED_PRESENT)), 1)
+CAR_SAFED_BARE ?= -I$(CAR_SW_DIR)/tests/bare-metal/safed
+CAR_SAFED_SW_OFFLOAD_TESTS := car-safed-sw-offload-tests
+endif
+
+CAR_SW_INCLUDES    = -I$(CAR_SW_DIR)/include $(CAR_SAFED_BARE) $(CAR_PULPD_BARE) -I$(CHS_SW_DIR)/include $(CHS_SW_DEPS_INCS)
 CAR_SW_LIB_SRCS_S  = $(wildcard $(CAR_SW_DIR)/lib/*.S $(CAR_SW_DIR)/lib/**/*.S)
 CAR_SW_LIB_SRCS_C  = $(wildcard $(CAR_SW_DIR)/lib/*.c $(CAR_SW_DIR)/lib/**/*.c)
 CAR_SW_LIB_SRCS_O  = $(CAR_SW_DEPS_SRCS:.c=.o) $(CAR_SW_LIB_SRCS_S:.S=.o) $(CAR_SW_LIB_SRCS_C:.c=.o)
@@ -72,7 +81,7 @@ CAR_SW_TEST_L2_DUMP	= $(CAR_SW_TEST_SRCS_S:.S=.car.l2.dump)   $(CAR_SW_TEST_SRCS
 CAR_SW_TEST_SPM_ROMH	= $(CAR_SW_TEST_SRCS_S:.S=.car.rom.memh)  $(CAR_SW_TEST_SRCS_C:.c=.car.rom.memh)
 CAR_SW_TEST_SPM_GPTH	= $(CAR_SW_TEST_SRCS_S:.S=.car.gpt.memh)  $(CAR_SW_TEST_SRCS_C:.c=.car.gpt.memh)
 
-car-sw-tests: $(CAR_SW_TEST_DRAM_DUMP) $(CAR_SW_TEST_SPM_DUMP) $(CAR_SW_TEST_L2_DUMP) $(CAR_SW_TEST_DRAM_SLM) $(CAR_SW_TEST_SPM_ROMH) $(CAR_SW_TEST_SPM_GPTH) car-pulpd-sw-offload-tests car-safed-sw-offload-tests mibench-automotive
+car-sw-tests: $(CAR_SW_TEST_DRAM_DUMP) $(CAR_SW_TEST_SPM_DUMP) $(CAR_SW_TEST_L2_DUMP) $(CAR_SW_TEST_DRAM_SLM) $(CAR_SW_TEST_SPM_ROMH) $(CAR_SW_TEST_SPM_GPTH) $(CAR_PULPD_SW_OFFLOAD_TESTS) $(CAR_SAFED_SW_OFFLOAD_TESTS) mibench-automotive
 
 # Generate .slm files from elf binaries. Only used when linking against external dram
 %.car.dram.slm: %.car.dram.elf
@@ -94,16 +103,21 @@ define offload_tests_template
 endef
 
 # Safety Island offload tests
+ifeq ($(shell echo $(SAFED_PRESENT)), 1)
 include $(CAR_SW_DIR)/tests/bare-metal/safed/sw.mk
 
 car-safed-sw-offload-tests:
 	$(call offload_tests_template,$(SAFED_HEADER_TARGETS),safed,$(CAR_ELFLOAD_BLOCKING_SAFED_SRC_C),$(CAR_ELFLOAD_BLOCKING_SAFED_PATH))
+endif
 
 # Integer Cluster offload tests
+ifeq ($(shell echo $(PULPD_PRESENT)), 1)
 include $(CAR_SW_DIR)/tests/bare-metal/pulpd/sw.mk
 
 car-pulpd-sw-offload-tests:
 	$(call offload_tests_template,$(PULPD_HEADER_TARGETS),pulpd,$(CAR_ELFLOAD_BLOCKING_PULPD_SRC_C),$(CAR_ELFLOAD_BLOCKING_PULPD_PATH))
+
+endif
 
 # Litmus tests
 LITMUS_REPO := https://github.com/pulp-platform/CHERI-Litmus.git


### PR DESCRIPTION
Since the HW design became highly parametric, this PR intends to reflect such parametrization also to the SW compilation and hardware initialization.
The `env` script containing the environment parameters for the design should also contain the export to some environment variables that define wether an island is used or not. These environment variables allow for:

* Compiling the software only for the islands that are actually used.
* Skipping the code generation of islands that are not intended to use.

Could be interesting to backport it to Carfield, @alex96295 what do you think?
This PR also alignes Cheshire so that:

* It points to a CVA6-SDK dedicated to Astral that is removing SSH link to Buildroot.
* It has a working CI.