### PR TITLE
[FIX] Aligning L2 size within Linker script

### DIFF
--- a/carfield.mk
+++ b/carfield.mk
@@ -47,7 +47,7 @@ include $(CAR_ROOT)/bender-safed.mk
 ######################
 
 CAR_NONFREE_REMOTE ?= git@iis-git.ee.ethz.ch:astral/astral-nonfree.git
-CAR_NONFREE_COMMIT ?= 6c6b2064e03cccf54c70cb9d754ec112a43332b1 # branch: master
+CAR_NONFREE_COMMIT ?= e8e4354d084cf1cfe6eb9b3bae6af381ef9108b1 # branch: master
 
 ## @section Carfield platform nonfree components
 ## Clone the non-free verification IP for Carfield. Some components such as CI scripts and ASIC

--- a/sw/link/l2.ld
+++ b/sw/link/l2.ld
@@ -10,7 +10,7 @@
 INCLUDE common.ldh
 
 MEMORY {
-  l2 (rwx)    : ORIGIN = 0x78000000, LENGTH = 1M
+  l2 (rwx)    : ORIGIN = 0x78000000, LENGTH = 128K
 }
 
 SECTIONS {


### PR DESCRIPTION
Was not aligned, still fixed to 1MB as Carfield.
Decrased to 128K as we have that much L2 in Astral.