### PR TITLE
[SECD] Fix secure boot

### DIFF
--- a/Bender.lock
+++ b/Bender.lock
@@ -368,7 +368,7 @@ packages:
     - common_cells
     - common_verification
   opentitan:
-    revision: faca6f28e20195e9b56eb822c58bec4a3a19dd4f
+    revision: ee29572e952fd96f12ba66ba339e77f0d9b83e4a
     version: null
     source:
       Git: https://github.com/pulp-platform/opentitan.git

--- a/Bender.yml
+++ b/Bender.yml
@@ -18,7 +18,7 @@ dependencies:
   dyn_mem:            { git: https://github.com/pulp-platform/dyn_spm.git,              rev: 480590062742230dc9bd4050358a15b4747bdf34 } # branch: main
   safety_island:      { git: https://github.com/pulp-platform/safety_island.git,        rev: aaef55c798ab53560faaf451a86668fa1e6d0f3b } # branch: carfield
   pulp_cluster:       { git: https://github.com/pulp-platform/pulp_cluster.git,         rev: 2cd26c4923570ae81297c06078a0cfcded1e761c } # branch: astral
-  opentitan:          { git: https://github.com/pulp-platform/opentitan.git,            rev: faca6f28e20195e9b56eb822c58bec4a3a19dd4f } # branch: mc/astral
+  opentitan:          { git: https://github.com/pulp-platform/opentitan.git,            rev: ee29572e952fd96f12ba66ba339e77f0d9b83e4a } # branch: mc/astral
   mailbox_unit:       { git: https://github.com/pulp-platform/mailbox_unit.git,         version: 1.1.0                                }
   apb:                { git: https://github.com/pulp-platform/apb.git,                  version: 0.2.3                                }
   timer_unit:         { git: https://github.com/pulp-platform/timer_unit.git,           version: 1.0.2                                }


### PR DESCRIPTION
Updated bootrom with correct emul. flash size. Now the secure boot works correctly. Bumping Opentitan.