### PR TITLE
Minor fixes to package and registers

### DIFF
--- a/hw/carfield_pkg.sv
+++ b/hw/carfield_pkg.sv
@@ -319,7 +319,6 @@ function automatic int unsigned gen_carfield_domains(islands_cfg_t island_cfg);
   if (island_cfg.spatz.enable   ) begin ret++; end
   if (island_cfg.pulp.enable    ) begin ret++; end
   if (island_cfg.secured.enable ) begin ret++; end
-  if (island_cfg.ethernet.enable) begin ret++; end
   return ret;
 endfunction
 
@@ -399,7 +398,6 @@ function automatic carfield_domain_idx_t gen_domain_idx(islands_cfg_t island_cfg
   if (island_cfg.pulp.enable     ) begin ret.pulp    = i; i++; end
   if (island_cfg.spatz.enable    ) begin ret.spatz   = i; i++; end
   if (island_cfg.l2_port0.enable ) begin ret.l2      = i; i++; end
-  if (island_cfg.ethernet.enable ) begin ret.ethernet= i; i++; end
   return ret;
 endfunction
 

--- a/hw/regs/carfield_reg_top.sv
+++ b/hw/regs/carfield_reg_top.sv
@@ -1095,7 +1095,7 @@ module carfield_reg_top #(
   prim_subreg #(
     .DW      (2),
     .SWACCESS("RW"),
-    .RESVAL  (2'h1)
+    .RESVAL  (2'h3)
   ) u_security_island_clk_sel (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),

--- a/hw/regs/carfield_regs.csv
+++ b/hw/regs/carfield_regs.csv
@@ -32,12 +32,12 @@ SECURITY_ISLAND_CLK_EN,1,rw,hro,0,0,Security Island clk gate enable
 PULP_CLUSTER_CLK_EN,1,rw,hro,0,0,PULP Cluster clk gate enable
 SPATZ_CLUSTER_CLK_EN,1,rw,hro,0,0,Spatz Cluster clk gate enable
 L2_CLK_EN,1,rw,hro,0,1,Shared L2 memory clk gate enable
-PERIPH_CLK_SEL,2,rw,hro,0,2,"Periph Domain pll select (0 -> host pll, 1 -> alt PLL, 2 -> per pll)"
-SAFETY_ISLAND_CLK_SEL,2,rw,hro,0,1,"Safety Island pll select (0 -> host pll, 1 -> alt PLL, 2 -> per pll)"
-SECURITY_ISLAND_CLK_SEL,2,rw,hro,0,1,"Security Island pll select (0 -> host pll, 1 -> alt PLL, 2 -> per pll)"
-PULP_CLUSTER_CLK_SEL,2,rw,hro,0,1,"PULP Cluster pll select (0 -> host pll, 1 -> alt PLL, 2 -> per pll)"
-SPATZ_CLUSTER_CLK_SEL,2,rw,hro,0,1,"Spatz Cluster pll select (0 -> host pll, 1 -> alt PLL, 2 -> per pll)"
-L2_CLK_SEL,2,rw,hro,0,1,"L2 Memory pll select (0 -> host pll, 1 -> alt PLL, 2 -> per pll)"
+PERIPH_CLK_SEL,2,rw,hro,0,2,"Periph Domain fll select (0 -> host fll, 1 -> alt fll, 2 -> per fll, 3 -> secd fll)"
+SAFETY_ISLAND_CLK_SEL,2,rw,hro,0,1,"Safety Island fll select (0 -> host fll, 1 -> alt fll, 2 -> per fll, 3 -> secd fll)"
+SECURITY_ISLAND_CLK_SEL,2,rw,hro,0,3,"Security Island fll select (0 -> host fll, 1 -> alt fll, 2 -> per fll, 3 -> secd fll)"
+PULP_CLUSTER_CLK_SEL,2,rw,hro,0,1,"PULP Cluster fll select (0 -> host fll, 1 -> alt fll, 2 -> per fll, 3 -> secd fll)"
+SPATZ_CLUSTER_CLK_SEL,2,rw,hro,0,1,"Spatz Cluster fll select (0 -> host fll, 1 -> alt fll, 2 -> per fll, 3 -> secd fll)"
+L2_CLK_SEL,2,rw,hro,0,1,"L2 Memory fll select (0 -> host fll, 1 -> alt fll, 2 -> per fll, 3 -> secd fll)"
 PERIPH_CLK_DIV_VALUE,24,rw,hro,1,1,Periph Domain clk divider value
 SAFETY_ISLAND_CLK_DIV_VALUE,24,rw,hro,1,1,Safety Island clk divider value
 SECURITY_ISLAND_CLK_DIV_VALUE,24,rw,hro,1,1,Security Island clk divider value

--- a/hw/regs/carfield_regs.hjson
+++ b/hw/regs/carfield_regs.hjson
@@ -376,7 +376,7 @@
     }
 
     { name: "PERIPH_CLK_SEL",
-      desc: "Periph Domain pll select (0 -> host pll, 1 -> alt PLL, 2 -> per pll)",
+      desc: "Periph Domain fll select (0 -> host fll, 1 -> alt fll, 2 -> per fll, 3 -> secd fll)",
       swaccess: "rw",
       hwaccess: "hro",
       resval: "2",
@@ -387,7 +387,7 @@
     }
 
     { name: "SAFETY_ISLAND_CLK_SEL",
-      desc: "Safety Island pll select (0 -> host pll, 1 -> alt PLL, 2 -> per pll)",
+      desc: "Safety Island fll select (0 -> host fll, 1 -> alt fll, 2 -> per fll, 3 -> secd fll)",
       swaccess: "rw",
       hwaccess: "hro",
       resval: "1",
@@ -398,10 +398,10 @@
     }
 
     { name: "SECURITY_ISLAND_CLK_SEL",
-      desc: "Security Island pll select (0 -> host pll, 1 -> alt PLL, 2 -> per pll)",
+      desc: "Security Island fll select (0 -> host fll, 1 -> alt fll, 2 -> per fll, 3 -> secd fll)",
       swaccess: "rw",
       hwaccess: "hro",
-      resval: "1",
+      resval: "3",
       hwqe: "0",
       fields: [
         { bits: "1:0" }
@@ -409,7 +409,7 @@
     }
 
     { name: "PULP_CLUSTER_CLK_SEL",
-      desc: "PULP Cluster pll select (0 -> host pll, 1 -> alt PLL, 2 -> per pll)",
+      desc: "PULP Cluster fll select (0 -> host fll, 1 -> alt fll, 2 -> per fll, 3 -> secd fll)",
       swaccess: "rw",
       hwaccess: "hro",
       resval: "1",
@@ -420,7 +420,7 @@
     }
 
     { name: "SPATZ_CLUSTER_CLK_SEL",
-      desc: "Spatz Cluster pll select (0 -> host pll, 1 -> alt PLL, 2 -> per pll)",
+      desc: "Spatz Cluster fll select (0 -> host fll, 1 -> alt fll, 2 -> per fll, 3 -> secd fll)",
       swaccess: "rw",
       hwaccess: "hro",
       resval: "1",
@@ -431,7 +431,7 @@
     }
 
     { name: "L2_CLK_SEL",
-      desc: "L2 Memory pll select (0 -> host pll, 1 -> alt PLL, 2 -> per pll)",
+      desc: "L2 Memory fll select (0 -> host fll, 1 -> alt fll, 2 -> per fll, 3 -> secd fll)",
       swaccess: "rw",
       hwaccess: "hro",
       resval: "1",

--- a/hw/regs/pcr.md
+++ b/hw/regs/pcr.md
@@ -1,74 +1,74 @@
 ## Summary
 
-| Name                                                                         | Offset   |   Length | Description                                                            |
-|:-----------------------------------------------------------------------------|:---------|---------:|:-----------------------------------------------------------------------|
-| carfield.[`VERSION0`](#version0)                                             | 0x0      |        4 | Cheshire sha256 commit                                                 |
-| carfield.[`VERSION1`](#version1)                                             | 0x4      |        4 | Safety Island sha256 commit                                            |
-| carfield.[`VERSION2`](#version2)                                             | 0x8      |        4 | Security Island sha256 commit                                          |
-| carfield.[`VERSION3`](#version3)                                             | 0xc      |        4 | PULP Cluster sha256 commit                                             |
-| carfield.[`VERSION4`](#version4)                                             | 0x10     |        4 | Spatz CLuster sha256 commit                                            |
-| carfield.[`JEDEC_IDCODE`](#jedec_idcode)                                     | 0x14     |        4 | JEDEC ID CODE -TODO assign-                                            |
-| carfield.[`GENERIC_SCRATCH0`](#generic_scratch0)                             | 0x18     |        4 | Scratch                                                                |
-| carfield.[`GENERIC_SCRATCH1`](#generic_scratch1)                             | 0x1c     |        4 | Scratch                                                                |
-| carfield.[`HOST_RST`](#host_rst)                                             | 0x20     |        4 | Host Domain reset -active high, inverted in HW-                        |
-| carfield.[`PERIPH_RST`](#periph_rst)                                         | 0x24     |        4 | Periph Domain reset -active high, inverted in HW-                      |
-| carfield.[`SAFETY_ISLAND_RST`](#safety_island_rst)                           | 0x28     |        4 | Safety Island reset -active high, inverted in HW-                      |
-| carfield.[`SECURITY_ISLAND_RST`](#security_island_rst)                       | 0x2c     |        4 | Security Island reset -active high, inverted in HW-                    |
-| carfield.[`PULP_CLUSTER_RST`](#pulp_cluster_rst)                             | 0x30     |        4 | PULP Cluster reset -active high, inverted in HW-                       |
-| carfield.[`SPATZ_CLUSTER_RST`](#spatz_cluster_rst)                           | 0x34     |        4 | Spatz Cluster reset -active high, inverted in HW-                      |
-| carfield.[`L2_RST`](#l2_rst)                                                 | 0x38     |        4 | L2 reset -active high, inverted in HW-                                 |
-| carfield.[`PERIPH_ISOLATE`](#periph_isolate)                                 | 0x3c     |        4 | Periph Domain  AXI isolate                                             |
-| carfield.[`SAFETY_ISLAND_ISOLATE`](#safety_island_isolate)                   | 0x40     |        4 | Safety Island AXI isolate                                              |
-| carfield.[`SECURITY_ISLAND_ISOLATE`](#security_island_isolate)               | 0x44     |        4 | Security Island AXI isolate                                            |
-| carfield.[`PULP_CLUSTER_ISOLATE`](#pulp_cluster_isolate)                     | 0x48     |        4 | PULP Cluster AXI isolate                                               |
-| carfield.[`SPATZ_CLUSTER_ISOLATE`](#spatz_cluster_isolate)                   | 0x4c     |        4 | Spatz Cluster AXI isolate                                              |
-| carfield.[`L2_ISOLATE`](#l2_isolate)                                         | 0x50     |        4 | L2 AXI isolate                                                         |
-| carfield.[`PERIPH_ISOLATE_STATUS`](#periph_isolate_status)                   | 0x54     |        4 | Periph Domain AXI isolate status                                       |
-| carfield.[`SAFETY_ISLAND_ISOLATE_STATUS`](#safety_island_isolate_status)     | 0x58     |        4 | Safety Island AXI isolate status                                       |
-| carfield.[`SECURITY_ISLAND_ISOLATE_STATUS`](#security_island_isolate_status) | 0x5c     |        4 | Security Island AXI isolate status                                     |
-| carfield.[`PULP_CLUSTER_ISOLATE_STATUS`](#pulp_cluster_isolate_status)       | 0x60     |        4 | PULP Cluster AXI isolate status                                        |
-| carfield.[`SPATZ_CLUSTER_ISOLATE_STATUS`](#spatz_cluster_isolate_status)     | 0x64     |        4 | Spatz Cluster AXI isolate status                                       |
-| carfield.[`L2_ISOLATE_STATUS`](#l2_isolate_status)                           | 0x68     |        4 | L2 AXI isolate status                                                  |
-| carfield.[`PERIPH_CLK_EN`](#periph_clk_en)                                   | 0x6c     |        4 | Periph Domain clk gate enable                                          |
-| carfield.[`SAFETY_ISLAND_CLK_EN`](#safety_island_clk_en)                     | 0x70     |        4 | Safety Island clk gate enable                                          |
-| carfield.[`SECURITY_ISLAND_CLK_EN`](#security_island_clk_en)                 | 0x74     |        4 | Security Island clk gate enable                                        |
-| carfield.[`PULP_CLUSTER_CLK_EN`](#pulp_cluster_clk_en)                       | 0x78     |        4 | PULP Cluster clk gate enable                                           |
-| carfield.[`SPATZ_CLUSTER_CLK_EN`](#spatz_cluster_clk_en)                     | 0x7c     |        4 | Spatz Cluster clk gate enable                                          |
-| carfield.[`L2_CLK_EN`](#l2_clk_en)                                           | 0x80     |        4 | Shared L2 memory clk gate enable                                       |
-| carfield.[`PERIPH_CLK_SEL`](#periph_clk_sel)                                 | 0x84     |        4 | Periph Domain pll select (0 -> host pll, 1 -> alt PLL, 2 -> per pll)   |
-| carfield.[`SAFETY_ISLAND_CLK_SEL`](#safety_island_clk_sel)                   | 0x88     |        4 | Safety Island pll select (0 -> host pll, 1 -> alt PLL, 2 -> per pll)   |
-| carfield.[`SECURITY_ISLAND_CLK_SEL`](#security_island_clk_sel)               | 0x8c     |        4 | Security Island pll select (0 -> host pll, 1 -> alt PLL, 2 -> per pll) |
-| carfield.[`PULP_CLUSTER_CLK_SEL`](#pulp_cluster_clk_sel)                     | 0x90     |        4 | PULP Cluster pll select (0 -> host pll, 1 -> alt PLL, 2 -> per pll)    |
-| carfield.[`SPATZ_CLUSTER_CLK_SEL`](#spatz_cluster_clk_sel)                   | 0x94     |        4 | Spatz Cluster pll select (0 -> host pll, 1 -> alt PLL, 2 -> per pll)   |
-| carfield.[`L2_CLK_SEL`](#l2_clk_sel)                                         | 0x98     |        4 | L2 Memory pll select (0 -> host pll, 1 -> alt PLL, 2 -> per pll)       |
-| carfield.[`PERIPH_CLK_DIV_VALUE`](#periph_clk_div_value)                     | 0x9c     |        4 | Periph Domain clk divider value                                        |
-| carfield.[`SAFETY_ISLAND_CLK_DIV_VALUE`](#safety_island_clk_div_value)       | 0xa0     |        4 | Safety Island clk divider value                                        |
-| carfield.[`SECURITY_ISLAND_CLK_DIV_VALUE`](#security_island_clk_div_value)   | 0xa4     |        4 | Security Island clk divider value                                      |
-| carfield.[`PULP_CLUSTER_CLK_DIV_VALUE`](#pulp_cluster_clk_div_value)         | 0xa8     |        4 | PULP Cluster clk divider value                                         |
-| carfield.[`SPATZ_CLUSTER_CLK_DIV_VALUE`](#spatz_cluster_clk_div_value)       | 0xac     |        4 | Spatz Cluster clk divider value                                        |
-| carfield.[`L2_CLK_DIV_VALUE`](#l2_clk_div_value)                             | 0xb0     |        4 | L2 Memory clk divider value                                            |
-| carfield.[`HOST_FETCH_ENABLE`](#host_fetch_enable)                           | 0xb4     |        4 | Host Domain fetch enable                                               |
-| carfield.[`SAFETY_ISLAND_FETCH_ENABLE`](#safety_island_fetch_enable)         | 0xb8     |        4 | Safety Island fetch enable                                             |
-| carfield.[`SECURITY_ISLAND_FETCH_ENABLE`](#security_island_fetch_enable)     | 0xbc     |        4 | Security Island fetch enable                                           |
-| carfield.[`PULP_CLUSTER_FETCH_ENABLE`](#pulp_cluster_fetch_enable)           | 0xc0     |        4 | PULP Cluster fetch enable                                              |
-| carfield.[`SPATZ_CLUSTER_DEBUG_REQ`](#spatz_cluster_debug_req)               | 0xc4     |        4 | Spatz Cluster debug req                                                |
-| carfield.[`HOST_BOOT_ADDR`](#host_boot_addr)                                 | 0xc8     |        4 | Host boot address                                                      |
-| carfield.[`SAFETY_ISLAND_BOOT_ADDR`](#safety_island_boot_addr)               | 0xcc     |        4 | Safety Island boot address                                             |
-| carfield.[`SECURITY_ISLAND_BOOT_ADDR`](#security_island_boot_addr)           | 0xd0     |        4 | Security Island boot address                                           |
-| carfield.[`PULP_CLUSTER_BOOT_ADDR`](#pulp_cluster_boot_addr)                 | 0xd4     |        4 | PULP Cluster boot address                                              |
-| carfield.[`SPATZ_CLUSTER_BOOT_ADDR`](#spatz_cluster_boot_addr)               | 0xd8     |        4 | Spatz Cluster boot address                                             |
-| carfield.[`PULP_CLUSTER_BOOT_ENABLE`](#pulp_cluster_boot_enable)             | 0xdc     |        4 | PULP Cluster boot enable                                               |
-| carfield.[`SPATZ_CLUSTER_BUSY`](#spatz_cluster_busy)                         | 0xe0     |        4 | Spatz Cluster busy                                                     |
-| carfield.[`PULP_CLUSTER_BUSY`](#pulp_cluster_busy)                           | 0xe4     |        4 | PULP Cluster busy                                                      |
-| carfield.[`PULP_CLUSTER_EOC`](#pulp_cluster_eoc)                             | 0xe8     |        4 | PULP Cluster end of computation                                        |
-| carfield.[`ETH_CLK_DIV_EN`](#eth_clk_div_en)                                 | 0xec     |        4 | Ethernet clock divider enable bit                                      |
-| carfield.[`ETH_CLK_DIV_VALUE`](#eth_clk_div_value)                           | 0xf0     |        4 | Ethernet clock divider value                                           |
-| carfield.[`HYPERBUS_CLK_DIV_EN`](#hyperbus_clk_div_en)                       | 0xf4     |        4 | Hyperbus clock divider enable bit                                      |
-| carfield.[`HYPERBUS_CLK_DIV_VALUE`](#hyperbus_clk_div_value)                 | 0xf8     |        4 | Hyperbus clock divider value                                           |
-| carfield.[`STREAMER_CLK_DIV_ENABLE`](#streamer_clk_div_enable)               | 0xfc     |        4 | Streamer clock divider enable                                          |
-| carfield.[`STREAMER_CLK_DIV_VALUE`](#streamer_clk_div_value)                 | 0x100    |        4 | Streamer clock divider value                                           |
-| carfield.[`STREAMER_GENERAL_IRQ`](#streamer_general_irq)                     | 0x104    |        4 | Streamer general interrupt                                             |
-| carfield.[`SPW_GENERAL_IRQ`](#spw_general_irq)                               | 0x108    |        4 | SpaceWire general interrupt                                            |
+| Name                                                                         | Offset   |   Length | Description                                                                           |
+|:-----------------------------------------------------------------------------|:---------|---------:|:--------------------------------------------------------------------------------------|
+| carfield.[`VERSION0`](#version0)                                             | 0x0      |        4 | Cheshire sha256 commit                                                                |
+| carfield.[`VERSION1`](#version1)                                             | 0x4      |        4 | Safety Island sha256 commit                                                           |
+| carfield.[`VERSION2`](#version2)                                             | 0x8      |        4 | Security Island sha256 commit                                                         |
+| carfield.[`VERSION3`](#version3)                                             | 0xc      |        4 | PULP Cluster sha256 commit                                                            |
+| carfield.[`VERSION4`](#version4)                                             | 0x10     |        4 | Spatz CLuster sha256 commit                                                           |
+| carfield.[`JEDEC_IDCODE`](#jedec_idcode)                                     | 0x14     |        4 | JEDEC ID CODE -TODO assign-                                                           |
+| carfield.[`GENERIC_SCRATCH0`](#generic_scratch0)                             | 0x18     |        4 | Scratch                                                                               |
+| carfield.[`GENERIC_SCRATCH1`](#generic_scratch1)                             | 0x1c     |        4 | Scratch                                                                               |
+| carfield.[`HOST_RST`](#host_rst)                                             | 0x20     |        4 | Host Domain reset -active high, inverted in HW-                                       |
+| carfield.[`PERIPH_RST`](#periph_rst)                                         | 0x24     |        4 | Periph Domain reset -active high, inverted in HW-                                     |
+| carfield.[`SAFETY_ISLAND_RST`](#safety_island_rst)                           | 0x28     |        4 | Safety Island reset -active high, inverted in HW-                                     |
+| carfield.[`SECURITY_ISLAND_RST`](#security_island_rst)                       | 0x2c     |        4 | Security Island reset -active high, inverted in HW-                                   |
+| carfield.[`PULP_CLUSTER_RST`](#pulp_cluster_rst)                             | 0x30     |        4 | PULP Cluster reset -active high, inverted in HW-                                      |
+| carfield.[`SPATZ_CLUSTER_RST`](#spatz_cluster_rst)                           | 0x34     |        4 | Spatz Cluster reset -active high, inverted in HW-                                     |
+| carfield.[`L2_RST`](#l2_rst)                                                 | 0x38     |        4 | L2 reset -active high, inverted in HW-                                                |
+| carfield.[`PERIPH_ISOLATE`](#periph_isolate)                                 | 0x3c     |        4 | Periph Domain  AXI isolate                                                            |
+| carfield.[`SAFETY_ISLAND_ISOLATE`](#safety_island_isolate)                   | 0x40     |        4 | Safety Island AXI isolate                                                             |
+| carfield.[`SECURITY_ISLAND_ISOLATE`](#security_island_isolate)               | 0x44     |        4 | Security Island AXI isolate                                                           |
+| carfield.[`PULP_CLUSTER_ISOLATE`](#pulp_cluster_isolate)                     | 0x48     |        4 | PULP Cluster AXI isolate                                                              |
+| carfield.[`SPATZ_CLUSTER_ISOLATE`](#spatz_cluster_isolate)                   | 0x4c     |        4 | Spatz Cluster AXI isolate                                                             |
+| carfield.[`L2_ISOLATE`](#l2_isolate)                                         | 0x50     |        4 | L2 AXI isolate                                                                        |
+| carfield.[`PERIPH_ISOLATE_STATUS`](#periph_isolate_status)                   | 0x54     |        4 | Periph Domain AXI isolate status                                                      |
+| carfield.[`SAFETY_ISLAND_ISOLATE_STATUS`](#safety_island_isolate_status)     | 0x58     |        4 | Safety Island AXI isolate status                                                      |
+| carfield.[`SECURITY_ISLAND_ISOLATE_STATUS`](#security_island_isolate_status) | 0x5c     |        4 | Security Island AXI isolate status                                                    |
+| carfield.[`PULP_CLUSTER_ISOLATE_STATUS`](#pulp_cluster_isolate_status)       | 0x60     |        4 | PULP Cluster AXI isolate status                                                       |
+| carfield.[`SPATZ_CLUSTER_ISOLATE_STATUS`](#spatz_cluster_isolate_status)     | 0x64     |        4 | Spatz Cluster AXI isolate status                                                      |
+| carfield.[`L2_ISOLATE_STATUS`](#l2_isolate_status)                           | 0x68     |        4 | L2 AXI isolate status                                                                 |
+| carfield.[`PERIPH_CLK_EN`](#periph_clk_en)                                   | 0x6c     |        4 | Periph Domain clk gate enable                                                         |
+| carfield.[`SAFETY_ISLAND_CLK_EN`](#safety_island_clk_en)                     | 0x70     |        4 | Safety Island clk gate enable                                                         |
+| carfield.[`SECURITY_ISLAND_CLK_EN`](#security_island_clk_en)                 | 0x74     |        4 | Security Island clk gate enable                                                       |
+| carfield.[`PULP_CLUSTER_CLK_EN`](#pulp_cluster_clk_en)                       | 0x78     |        4 | PULP Cluster clk gate enable                                                          |
+| carfield.[`SPATZ_CLUSTER_CLK_EN`](#spatz_cluster_clk_en)                     | 0x7c     |        4 | Spatz Cluster clk gate enable                                                         |
+| carfield.[`L2_CLK_EN`](#l2_clk_en)                                           | 0x80     |        4 | Shared L2 memory clk gate enable                                                      |
+| carfield.[`PERIPH_CLK_SEL`](#periph_clk_sel)                                 | 0x84     |        4 | Periph Domain fll select (0 -> host fll, 1 -> alt fll, 2 -> per fll, 3 -> secd fll)   |
+| carfield.[`SAFETY_ISLAND_CLK_SEL`](#safety_island_clk_sel)                   | 0x88     |        4 | Safety Island fll select (0 -> host fll, 1 -> alt fll, 2 -> per fll, 3 -> secd fll)   |
+| carfield.[`SECURITY_ISLAND_CLK_SEL`](#security_island_clk_sel)               | 0x8c     |        4 | Security Island fll select (0 -> host fll, 1 -> alt fll, 2 -> per fll, 3 -> secd fll) |
+| carfield.[`PULP_CLUSTER_CLK_SEL`](#pulp_cluster_clk_sel)                     | 0x90     |        4 | PULP Cluster fll select (0 -> host fll, 1 -> alt fll, 2 -> per fll, 3 -> secd fll)    |
+| carfield.[`SPATZ_CLUSTER_CLK_SEL`](#spatz_cluster_clk_sel)                   | 0x94     |        4 | Spatz Cluster fll select (0 -> host fll, 1 -> alt fll, 2 -> per fll, 3 -> secd fll)   |
+| carfield.[`L2_CLK_SEL`](#l2_clk_sel)                                         | 0x98     |        4 | L2 Memory fll select (0 -> host fll, 1 -> alt fll, 2 -> per fll, 3 -> secd fll)       |
+| carfield.[`PERIPH_CLK_DIV_VALUE`](#periph_clk_div_value)                     | 0x9c     |        4 | Periph Domain clk divider value                                                       |
+| carfield.[`SAFETY_ISLAND_CLK_DIV_VALUE`](#safety_island_clk_div_value)       | 0xa0     |        4 | Safety Island clk divider value                                                       |
+| carfield.[`SECURITY_ISLAND_CLK_DIV_VALUE`](#security_island_clk_div_value)   | 0xa4     |        4 | Security Island clk divider value                                                     |
+| carfield.[`PULP_CLUSTER_CLK_DIV_VALUE`](#pulp_cluster_clk_div_value)         | 0xa8     |        4 | PULP Cluster clk divider value                                                        |
+| carfield.[`SPATZ_CLUSTER_CLK_DIV_VALUE`](#spatz_cluster_clk_div_value)       | 0xac     |        4 | Spatz Cluster clk divider value                                                       |
+| carfield.[`L2_CLK_DIV_VALUE`](#l2_clk_div_value)                             | 0xb0     |        4 | L2 Memory clk divider value                                                           |
+| carfield.[`HOST_FETCH_ENABLE`](#host_fetch_enable)                           | 0xb4     |        4 | Host Domain fetch enable                                                              |
+| carfield.[`SAFETY_ISLAND_FETCH_ENABLE`](#safety_island_fetch_enable)         | 0xb8     |        4 | Safety Island fetch enable                                                            |
+| carfield.[`SECURITY_ISLAND_FETCH_ENABLE`](#security_island_fetch_enable)     | 0xbc     |        4 | Security Island fetch enable                                                          |
+| carfield.[`PULP_CLUSTER_FETCH_ENABLE`](#pulp_cluster_fetch_enable)           | 0xc0     |        4 | PULP Cluster fetch enable                                                             |
+| carfield.[`SPATZ_CLUSTER_DEBUG_REQ`](#spatz_cluster_debug_req)               | 0xc4     |        4 | Spatz Cluster debug req                                                               |
+| carfield.[`HOST_BOOT_ADDR`](#host_boot_addr)                                 | 0xc8     |        4 | Host boot address                                                                     |
+| carfield.[`SAFETY_ISLAND_BOOT_ADDR`](#safety_island_boot_addr)               | 0xcc     |        4 | Safety Island boot address                                                            |
+| carfield.[`SECURITY_ISLAND_BOOT_ADDR`](#security_island_boot_addr)           | 0xd0     |        4 | Security Island boot address                                                          |
+| carfield.[`PULP_CLUSTER_BOOT_ADDR`](#pulp_cluster_boot_addr)                 | 0xd4     |        4 | PULP Cluster boot address                                                             |
+| carfield.[`SPATZ_CLUSTER_BOOT_ADDR`](#spatz_cluster_boot_addr)               | 0xd8     |        4 | Spatz Cluster boot address                                                            |
+| carfield.[`PULP_CLUSTER_BOOT_ENABLE`](#pulp_cluster_boot_enable)             | 0xdc     |        4 | PULP Cluster boot enable                                                              |
+| carfield.[`SPATZ_CLUSTER_BUSY`](#spatz_cluster_busy)                         | 0xe0     |        4 | Spatz Cluster busy                                                                    |
+| carfield.[`PULP_CLUSTER_BUSY`](#pulp_cluster_busy)                           | 0xe4     |        4 | PULP Cluster busy                                                                     |
+| carfield.[`PULP_CLUSTER_EOC`](#pulp_cluster_eoc)                             | 0xe8     |        4 | PULP Cluster end of computation                                                       |
+| carfield.[`ETH_CLK_DIV_EN`](#eth_clk_div_en)                                 | 0xec     |        4 | Ethernet clock divider enable bit                                                     |
+| carfield.[`ETH_CLK_DIV_VALUE`](#eth_clk_div_value)                           | 0xf0     |        4 | Ethernet clock divider value                                                          |
+| carfield.[`HYPERBUS_CLK_DIV_EN`](#hyperbus_clk_div_en)                       | 0xf4     |        4 | Hyperbus clock divider enable bit                                                     |
+| carfield.[`HYPERBUS_CLK_DIV_VALUE`](#hyperbus_clk_div_value)                 | 0xf8     |        4 | Hyperbus clock divider value                                                          |
+| carfield.[`STREAMER_CLK_DIV_ENABLE`](#streamer_clk_div_enable)               | 0xfc     |        4 | Streamer clock divider enable                                                         |
+| carfield.[`STREAMER_CLK_DIV_VALUE`](#streamer_clk_div_value)                 | 0x100    |        4 | Streamer clock divider value                                                          |
+| carfield.[`STREAMER_GENERAL_IRQ`](#streamer_general_irq)                     | 0x104    |        4 | Streamer general interrupt                                                            |
+| carfield.[`SPW_GENERAL_IRQ`](#spw_general_irq)                               | 0x108    |        4 | SpaceWire general interrupt                                                           |
 
 ## VERSION0
 Cheshire sha256 commit
@@ -624,7 +624,7 @@ Shared L2 memory clk gate enable
 |   0    |   rw   |   0x1   | L2_CLK_EN |               |
 
 ## PERIPH_CLK_SEL
-Periph Domain pll select (0 -> host pll, 1 -> alt PLL, 2 -> per pll)
+Periph Domain fll select (0 -> host fll, 1 -> alt fll, 2 -> per fll, 3 -> secd fll)
 - Offset: `0x84`
 - Reset default: `0x2`
 - Reset mask: `0x3`
@@ -641,7 +641,7 @@ Periph Domain pll select (0 -> host pll, 1 -> alt PLL, 2 -> per pll)
 |  1:0   |   rw   |   0x2   | PERIPH_CLK_SEL |               |
 
 ## SAFETY_ISLAND_CLK_SEL
-Safety Island pll select (0 -> host pll, 1 -> alt PLL, 2 -> per pll)
+Safety Island fll select (0 -> host fll, 1 -> alt fll, 2 -> per fll, 3 -> secd fll)
 - Offset: `0x88`
 - Reset default: `0x1`
 - Reset mask: `0x3`
@@ -658,9 +658,9 @@ Safety Island pll select (0 -> host pll, 1 -> alt PLL, 2 -> per pll)
 |  1:0   |   rw   |   0x1   | SAFETY_ISLAND_CLK_SEL |               |
 
 ## SECURITY_ISLAND_CLK_SEL
-Security Island pll select (0 -> host pll, 1 -> alt PLL, 2 -> per pll)
+Security Island fll select (0 -> host fll, 1 -> alt fll, 2 -> per fll, 3 -> secd fll)
 - Offset: `0x8c`
-- Reset default: `0x1`
+- Reset default: `0x3`
 - Reset mask: `0x3`
 
 ### Fields
@@ -672,10 +672,10 @@ Security Island pll select (0 -> host pll, 1 -> alt PLL, 2 -> per pll)
 |  Bits  |  Type  |  Reset  | Name                    | Description   |
 |:------:|:------:|:-------:|:------------------------|:--------------|
 |  31:2  |        |         |                         | Reserved      |
-|  1:0   |   rw   |   0x1   | SECURITY_ISLAND_CLK_SEL |               |
+|  1:0   |   rw   |   0x3   | SECURITY_ISLAND_CLK_SEL |               |
 
 ## PULP_CLUSTER_CLK_SEL
-PULP Cluster pll select (0 -> host pll, 1 -> alt PLL, 2 -> per pll)
+PULP Cluster fll select (0 -> host fll, 1 -> alt fll, 2 -> per fll, 3 -> secd fll)
 - Offset: `0x90`
 - Reset default: `0x1`
 - Reset mask: `0x3`
@@ -692,7 +692,7 @@ PULP Cluster pll select (0 -> host pll, 1 -> alt PLL, 2 -> per pll)
 |  1:0   |   rw   |   0x1   | PULP_CLUSTER_CLK_SEL |               |
 
 ## SPATZ_CLUSTER_CLK_SEL
-Spatz Cluster pll select (0 -> host pll, 1 -> alt PLL, 2 -> per pll)
+Spatz Cluster fll select (0 -> host fll, 1 -> alt fll, 2 -> per fll, 3 -> secd fll)
 - Offset: `0x94`
 - Reset default: `0x1`
 - Reset mask: `0x3`
@@ -709,7 +709,7 @@ Spatz Cluster pll select (0 -> host pll, 1 -> alt PLL, 2 -> per pll)
 |  1:0   |   rw   |   0x1   | SPATZ_CLUSTER_CLK_SEL |               |
 
 ## L2_CLK_SEL
-L2 Memory pll select (0 -> host pll, 1 -> alt PLL, 2 -> per pll)
+L2 Memory fll select (0 -> host fll, 1 -> alt fll, 2 -> per fll, 3 -> secd fll)
 - Offset: `0x98`
 - Reset default: `0x1`
 - Reset mask: `0x3`

--- a/sw/include/regs/soc_ctrl.h
+++ b/sw/include/regs/soc_ctrl.h
@@ -141,42 +141,48 @@ extern "C" {
 #define CARFIELD_L2_CLK_EN_REG_OFFSET 0x80
 #define CARFIELD_L2_CLK_EN_L2_CLK_EN_BIT 0
 
-// Periph Domain pll select (0 -> host pll, 1 -> alt PLL, 2 -> per pll)
+// Periph Domain fll select (0 -> host fll, 1 -> alt fll, 2 -> per fll, 3 ->
+// secd fll)
 #define CARFIELD_PERIPH_CLK_SEL_REG_OFFSET 0x84
 #define CARFIELD_PERIPH_CLK_SEL_PERIPH_CLK_SEL_MASK 0x3
 #define CARFIELD_PERIPH_CLK_SEL_PERIPH_CLK_SEL_OFFSET 0
 #define CARFIELD_PERIPH_CLK_SEL_PERIPH_CLK_SEL_FIELD \
   ((bitfield_field32_t) { .mask = CARFIELD_PERIPH_CLK_SEL_PERIPH_CLK_SEL_MASK, .index = CARFIELD_PERIPH_CLK_SEL_PERIPH_CLK_SEL_OFFSET })
 
-// Safety Island pll select (0 -> host pll, 1 -> alt PLL, 2 -> per pll)
+// Safety Island fll select (0 -> host fll, 1 -> alt fll, 2 -> per fll, 3 ->
+// secd fll)
 #define CARFIELD_SAFETY_ISLAND_CLK_SEL_REG_OFFSET 0x88
 #define CARFIELD_SAFETY_ISLAND_CLK_SEL_SAFETY_ISLAND_CLK_SEL_MASK 0x3
 #define CARFIELD_SAFETY_ISLAND_CLK_SEL_SAFETY_ISLAND_CLK_SEL_OFFSET 0
 #define CARFIELD_SAFETY_ISLAND_CLK_SEL_SAFETY_ISLAND_CLK_SEL_FIELD \
   ((bitfield_field32_t) { .mask = CARFIELD_SAFETY_ISLAND_CLK_SEL_SAFETY_ISLAND_CLK_SEL_MASK, .index = CARFIELD_SAFETY_ISLAND_CLK_SEL_SAFETY_ISLAND_CLK_SEL_OFFSET })
 
-// Security Island pll select (0 -> host pll, 1 -> alt PLL, 2 -> per pll)
+// Security Island fll select (0 -> host fll, 1 -> alt fll, 2 -> per fll, 3
+// -> secd fll)
 #define CARFIELD_SECURITY_ISLAND_CLK_SEL_REG_OFFSET 0x8c
 #define CARFIELD_SECURITY_ISLAND_CLK_SEL_SECURITY_ISLAND_CLK_SEL_MASK 0x3
 #define CARFIELD_SECURITY_ISLAND_CLK_SEL_SECURITY_ISLAND_CLK_SEL_OFFSET 0
 #define CARFIELD_SECURITY_ISLAND_CLK_SEL_SECURITY_ISLAND_CLK_SEL_FIELD \
   ((bitfield_field32_t) { .mask = CARFIELD_SECURITY_ISLAND_CLK_SEL_SECURITY_ISLAND_CLK_SEL_MASK, .index = CARFIELD_SECURITY_ISLAND_CLK_SEL_SECURITY_ISLAND_CLK_SEL_OFFSET })
 
-// PULP Cluster pll select (0 -> host pll, 1 -> alt PLL, 2 -> per pll)
+// PULP Cluster fll select (0 -> host fll, 1 -> alt fll, 2 -> per fll, 3 ->
+// secd fll)
 #define CARFIELD_PULP_CLUSTER_CLK_SEL_REG_OFFSET 0x90
 #define CARFIELD_PULP_CLUSTER_CLK_SEL_PULP_CLUSTER_CLK_SEL_MASK 0x3
 #define CARFIELD_PULP_CLUSTER_CLK_SEL_PULP_CLUSTER_CLK_SEL_OFFSET 0
 #define CARFIELD_PULP_CLUSTER_CLK_SEL_PULP_CLUSTER_CLK_SEL_FIELD \
   ((bitfield_field32_t) { .mask = CARFIELD_PULP_CLUSTER_CLK_SEL_PULP_CLUSTER_CLK_SEL_MASK, .index = CARFIELD_PULP_CLUSTER_CLK_SEL_PULP_CLUSTER_CLK_SEL_OFFSET })
 
-// Spatz Cluster pll select (0 -> host pll, 1 -> alt PLL, 2 -> per pll)
+// Spatz Cluster fll select (0 -> host fll, 1 -> alt fll, 2 -> per fll, 3 ->
+// secd fll)
 #define CARFIELD_SPATZ_CLUSTER_CLK_SEL_REG_OFFSET 0x94
 #define CARFIELD_SPATZ_CLUSTER_CLK_SEL_SPATZ_CLUSTER_CLK_SEL_MASK 0x3
 #define CARFIELD_SPATZ_CLUSTER_CLK_SEL_SPATZ_CLUSTER_CLK_SEL_OFFSET 0
 #define CARFIELD_SPATZ_CLUSTER_CLK_SEL_SPATZ_CLUSTER_CLK_SEL_FIELD \
   ((bitfield_field32_t) { .mask = CARFIELD_SPATZ_CLUSTER_CLK_SEL_SPATZ_CLUSTER_CLK_SEL_MASK, .index = CARFIELD_SPATZ_CLUSTER_CLK_SEL_SPATZ_CLUSTER_CLK_SEL_OFFSET })
 
-// L2 Memory pll select (0 -> host pll, 1 -> alt PLL, 2 -> per pll)
+// L2 Memory fll select (0 -> host fll, 1 -> alt fll, 2 -> per fll, 3 -> secd
+// fll)
 #define CARFIELD_L2_CLK_SEL_REG_OFFSET 0x98
 #define CARFIELD_L2_CLK_SEL_L2_CLK_SEL_MASK 0x3
 #define CARFIELD_L2_CLK_SEL_L2_CLK_SEL_OFFSET 0


### PR DESCRIPTION
This PR fix a bug in the generation of clock domains parameters by removing ethernet from domain's list (that in fact belongs to the peripheral domain).
In addition it updates the clock mux selector reset value of security domain since now it has its own dedicated clock.