### PR TITLE
Fix OpenTitan tests.

### DIFF
--- a/Bender.lock
+++ b/Bender.lock
@@ -374,7 +374,7 @@ packages:
     - common_cells
     - common_verification
   opentitan:
-    revision: 1466a339775f62ebec9fababe2859462bf9198b3
+    revision: cb163f0d8eefd896ceed8b83d2987e7feccf830e
     version: null
     source:
       Git: https://github.com/pulp-platform/opentitan.git

--- a/Bender.yml
+++ b/Bender.yml
@@ -18,7 +18,7 @@ dependencies:
   dyn_mem:            { git: https://github.com/pulp-platform/dyn_spm.git,              rev: 480590062742230dc9bd4050358a15b4747bdf34 } # branch: main
   safety_island:      { git: https://github.com/pulp-platform/safety_island.git,        rev: aaef55c798ab53560faaf451a86668fa1e6d0f3b } # branch: carfield
   pulp_cluster:       { git: https://github.com/pulp-platform/pulp_cluster.git,         rev: 069d77e162a4b2be4132d429135656b54d5150ba } # branch: astral
-  opentitan:          { git: https://github.com/pulp-platform/opentitan.git,            rev: 1466a339775f62ebec9fababe2859462bf9198b3 } # branch: mc/astral
+  opentitan:          { git: https://github.com/pulp-platform/opentitan.git,            rev: cb163f0d8eefd896ceed8b83d2987e7feccf830e } # branch: mc/astral
   mailbox_unit:       { git: https://github.com/pulp-platform/mailbox_unit.git,         version: 1.1.0                                }
   apb:                { git: https://github.com/pulp-platform/apb.git,                  version: 0.2.3                                }
   timer_unit:         { git: https://github.com/pulp-platform/timer_unit.git,           version: 1.0.2                                }

--- a/target/sim/src/astral_fix.sv
+++ b/target/sim/src/astral_fix.sv
@@ -906,7 +906,7 @@ module astral_fixture;
   /////////////////////////
 
   if (CarfieldIslandsCfg.secured.enable) begin: gen_scured_vip
-    localparam time ClkPeriodSecdJtag = ClkPeriodRef * 2;
+    localparam time ClkPeriodSecdJtag = ClkPeriodJtag / 5;
 
     // VIP
     vip_security_island_soc #(

--- a/target/sim/src/astral_fix.sv
+++ b/target/sim/src/astral_fix.sv
@@ -840,7 +840,8 @@ module astral_fixture;
   ///////////////////////
 
   if (CarfieldIslandsCfg.safed.enable) begin : gen_safed_vip
-    localparam time ClkPeriodSafedJtag = ClkPeriodRef * 2;
+    // We assume 50 MHz for Safety Island JTAG
+    localparam time ClkPeriodSafedJtag = 20 ns;
 
     localparam axi_in_t AxiIn = gen_axi_in(DutCfg);
     localparam int unsigned AxiSlvIdWidth = DutCfg.AxiMstIdWidth + $clog2(AxiIn.num_in);
@@ -906,7 +907,8 @@ module astral_fixture;
   /////////////////////////
 
   if (CarfieldIslandsCfg.secured.enable) begin: gen_scured_vip
-    localparam time ClkPeriodSecdJtag = ClkPeriodJtag / 5;
+    // We assume 50 MHz for OpenTitan JTAG
+    localparam time ClkPeriodSecdJtag = 20 ns;
 
     // VIP
     vip_security_island_soc #(

--- a/target/sim/src/astral_fix.sv
+++ b/target/sim/src/astral_fix.sv
@@ -906,7 +906,7 @@ module astral_fixture;
   // Security island VIP //
   /////////////////////////
 
-  if (CarfieldIslandsCfg.secured.enable) begin: gen_scured_vip
+  if (CarfieldIslandsCfg.secured.enable) begin: gen_secured_vip
     // We assume 50 MHz for OpenTitan JTAG
     localparam time ClkPeriodSecdJtag = 20 ns;
 

--- a/target/sim/src/astral_tb.sv
+++ b/target/sim/src/astral_tb.sv
@@ -309,8 +309,6 @@ module tb_astral;
         // Wait for FLL lock
         fix.wait_fll_lock();
 
-        wait (pad_configured.triggered);
-        
         // Writing max burst length in Hyperbus configuration registers to
         // prevent the Verification IPs from triggering timing checks.
         $display("[TB] INFO: Configuring Hyperbus through serial link.");

--- a/target/sim/src/astral_tb.sv
+++ b/target/sim/src/astral_tb.sv
@@ -300,7 +300,7 @@ module tb_astral;
       fix.set_secure_boot(secure_boot);
 
       // set bootmode
-      fix.gen_scured_vip.secd_vip.set_secd_boot_mode(secd_boot_mode);
+      fix.gen_secured_vip.secd_vip.set_secd_boot_mode(secd_boot_mode);
 
       if (secd_preload_elf != "" || secd_flash_vmem != "") begin
         // Wait for reset
@@ -319,16 +319,16 @@ module tb_astral;
             // Wait before security island HW is initialized
             repeat(10000)
               @(posedge fix.ref_clk);
-            fix.gen_scured_vip.secd_vip.debug_secd_module_init();
-            fix.gen_scured_vip.secd_vip.load_secd_binary(secd_preload_elf);
-            fix.gen_scured_vip.secd_vip.jtag_secd_data_preload();
-            fix.gen_scured_vip.secd_vip.jtag_secd_wakeup(32'hE0000080);
-            fix.gen_scured_vip.secd_vip.jtag_secd_wait_eoc();
+            fix.gen_secured_vip.secd_vip.debug_secd_module_init();
+            fix.gen_secured_vip.secd_vip.load_secd_binary(secd_preload_elf);
+            fix.gen_secured_vip.secd_vip.jtag_secd_data_preload();
+            fix.gen_secured_vip.secd_vip.jtag_secd_wakeup(32'hE0000080);
+            fix.gen_secured_vip.secd_vip.jtag_secd_wait_eoc();
           end 1: begin
-            fix.gen_scured_vip.secd_vip.spih_norflash_preload(secd_flash_vmem);
+            fix.gen_secured_vip.secd_vip.spih_norflash_preload(secd_flash_vmem);
             repeat(10000)
               @(posedge fix.ref_clk);
-            fix.gen_scured_vip.secd_vip.jtag_secd_wait_eoc();
+            fix.gen_secured_vip.secd_vip.jtag_secd_wait_eoc();
           end default: begin
             $fatal(1, "Unsupported boot mode %d (reserved)!", secd_boot_mode);
           end


### PR DESCRIPTION
Locking OpenTitan JTAG frequency to 50 MHz.
Bump OpenTitan with the updated bootrom for padframe configuration during the secure boot.